### PR TITLE
Style Go Ahead Button

### DIFF
--- a/hugo/themes/blank/assets/scss/user.scss
+++ b/hugo/themes/blank/assets/scss/user.scss
@@ -193,4 +193,10 @@ h3, .h3 {
     width: 100% !important;
   }
 
-  
+/* target the go ahead button */
+article>div:last-of-type>p:last-of-type>a:last-of-type{
+    @extend .btn,.btn-primary,.float-right;
+    &:after{
+      content: " →";  
+    }
+}


### PR DESCRIPTION
Styled the last link, in the last div, in the last paragraph. It's the "Go Ahead" button.

![Screenshot 2021-10-06 at 16 32 25](https://user-images.githubusercontent.com/228256/136278800-862bb8ae-b314-4775-a9f3-11d7cacab451.png)

Here's a preview. If you want to #Hacktoberfest this repo too I wouldn't mind :)
