### PR TITLE
remove always-false predicate from health-checks example

### DIFF
--- a/hugo/content/docs/health-checks.md
+++ b/hugo/content/docs/health-checks.md
@@ -22,10 +22,7 @@ public void ConfigureServices(IServiceCollection services)
         {
             endpoints.MapControllers();
 
-            endpoints.MapHealthChecks("/health/live", new HealthCheckOptions
-            {
-                Predicate = check => false
-            });
+            endpoints.MapHealthChecks("/health/live");
         });
 ```
 


### PR DESCRIPTION
The example was disabling all health-checks unconditionally, this doesn't seem needed in the sample code.