### PR TITLE
Update aws-provider-net.md

### DIFF
--- a/hugo/content/docs/cluster/aws-provider-net.md
+++ b/hugo/content/docs/cluster/aws-provider-net.md
@@ -13,14 +13,14 @@ Provider is available in `Proto.Cluster.AmazonECS` nuget package.
 static (GrpcNetRemoteConfig, IClusterProvider) ConfigureForAwsEcs(IConfiguration config)
     {
         var awsClient = new AmazonECSClient();
-        var containerInstanceName = config["ProtoActor:AwsContainerInstance"];
-        var ecsClusterName = config["ProtoActor:AwsEcsClusterName"];
+        var awsMetadataClient = new AwsEcsContainerMetadataHttpClient();
+        var taskMetadata = awsMetadataClient.GetTaskMetadata();
 
         var clusterProvider = new AmazonEcsProvider
             (
                 awsClient, 
-                ecsClusterName, 
-                containerInstanceName, 
+                taskMetadata.Cluster, 
+                taskMetadata.TaskARN, 
                 new AmazonEcsProviderConfig()
             );
 


### PR DESCRIPTION
Retrieve cluster and task names from the metadata endpoint. There already is a class within the ECS provider to get this info, might as well use it? It's a lot easier getting the task arn from the metadata rather than environment config.