### PR TITLE
Added info about cluster gossip interval and timeout configurations

### DIFF
--- a/hugo/content/docs/cluster/gossip.md
+++ b/hugo/content/docs/cluster/gossip.md
@@ -107,3 +107,11 @@ system
     x => x.Key == GossipKeys.MemberHeartbeat, 
     update => {....});
 ```    
+
+### Configuring cluster gossip interval 
+
+The default interval between gossip updates is 300 ms. Sometimes we might need to increase this interval, based on the overall load on the system. So, we can configure this interval using `ClusterConfig.WithGossipInterval(interval)`, where `interval` is of type `TimeSpan`. But setting the `interval` to a higher value might lead to some unexpected results, because it would take `interval` amount of time for all the members to come to a consensus, in case of updates in the actor system.  
+
+### Configuring cluster gossip request timeout
+
+The default timeout for sending the gossip to other members is 1500 ms. This can also be configured to the desired value using `ClusterConfig.WithGossipRequestTimeout(timeout)`, where `timeout` is of type `TimeSpan`.


### PR DESCRIPTION
The PR contains some useful information related to cluster gossip interval and timeout configurations. These configurations (beyond the default values) proved very helpful in my use case, when we operate the actor system under huge load. 
Hence, I thought to update the readme since it would benefit the community, and other members can get the information from the documentation, instead of browsing through the library code. 
Please let me know in case of any suggestions.