### PR TITLE
Additional information and code snippets on batch publishing messages

### DIFF
--- a/hugo/content/docs/envelope-pattern.md
+++ b/hugo/content/docs/envelope-pattern.md
@@ -7,21 +7,22 @@ A common use-case for actor-based event processing is to consume data from some 
 If you use some form of persistence in your event processor, be it plain snapshots of state or event-sourcing, this can result in writes to the database for each message processed.
 One message goes in, you process it, you write the new state of your entity/actor back to the persistent store.
 
-This can result in bottlenecks in terms of writes against the persistent store.
-e.g. if you process 10 000 messages per second, that could result in 10 000 writes to the persistent store.
+This can result in bottlenecks in terms of writes against the persistent store. For example, if you process 10,000 messages per second, that could result in 10,000 writes to the persistent store.
 
 This pattern limits the number of writes to the persistent store by grouping messages together, where you only write back once they are all processed, and then ack this back to the underlying message queue/log you are using.
 
+Besides the trivial use case of writing to persistent storage, sending messages in batch from one actor to the other improves performance significantly when the system is under load and processing lots of messages per second.
 
-Requires:
-* Idempotency, message deduplication in actor
 
-Pros:
+#### Requires:
+* Idempotency, message deduplication in actor (can be done using `Props.WithClusterRequestDeduplication(deduplicationWindow)`, where `deduplicationWindow` is an optional field and is of `TimeSpan` type)
+
+#### Pros:
 * High throughput processing
 * Guaranteed delivery of messages (at least once)
 * Guaranteed state persistence
 
-Cons:
+#### Cons:
 * Higher latency due to batching
 * Idempotency state and logic can add complexity
 
@@ -40,9 +41,31 @@ Cons:
 
 ![Cluster Events](images/batching-2.png)
 
+#### Sample code snippet:
+
+```csharp
+// Here we are using Proto.Cluster.PubSub.PubSubBatch to construct the envelope
+PubSubBatch pubSubBatch = new PubSubBatch();
+// Appending a custom message in the envelope
+// Note that messages of various types can be appended to the same envelope, but need to consider the logic at the receiving side
+pubSubBatch.Envelopes.Add(message);
+```
+
 ### Send the envelopes to the target actors
 
 ![Cluster Events](images/batching-3.png)
+
+#### Sample code snippet:
+
+```csharp
+// To publish the envelope to a grain (virtual actor)
+PublishResponse publishResponse = await Context.Cluster().RequestAsync<PublishResponse>(grainId, GrainActor.Kind, pubSubBatch, new CancellationTokenSource(1000).Token);
+
+// To publish the envelope to an actor
+PublishResponse publishResponse = await Context.RequestAsync<PublishResponse>(actorPid, pubSubBatch, new CancellationTokenSource(1000).Token);
+
+// The response can be used to ascertain whether the batch has been delivered successfully or not
+```
 
 ### Consume the envelopes in the actors
 
@@ -51,6 +74,29 @@ At this point, we process each message in the envelope, but we only commit state
 This strategy allows us to process messages at high throughput, while still guaranteeing persistence.
 
 ![Cluster Events](images/batching-4.png)
+
+#### Sample code snippet:
+
+```csharp
+// We need to process each message in the envelope
+// Implement additional logic in case the envelope contains messages of various types
+// This example is illustrated for grain (virtual actor)
+// In case of actor, process this message in the ReceiveAsync() overloaded method.
+public override async Task OnReceive()
+{
+    switch (Context.Message)
+    {
+        case PubSubBatch pubSubBatch:
+            foreach(MessageType message in pubSubBatch.Envelopes)
+            {
+                // process the message
+            }
+            // To send the response back to the batch publisher
+            Context.Respond(new PublishResponse());
+            break;
+    }
+}
+```
 
 ### Await Ack and commit offsets
 


### PR DESCRIPTION
This PR contains some useful code snippets for batch publishing messages from one actor to the other. 

Publishing messages in batch within actors significantly improves the performance under load. The code snippets are inspired from the `BatchingProducer.cs` library code of [ProtoCluster PubSub](https://github.com/asynkron/protoactor-dotnet/tree/dev/src/Proto.Cluster/PubSub). 
I have tested the same in my application, and the results were promising! Hence, decided to update the docs.

Please let me know in case of any suggestions or doubts.