### PR TITLE
Updated observability information for OpenTelemetry AutoInstrumentation

### DIFF
--- a/hugo/content/docs/logging.md
+++ b/hugo/content/docs/logging.md
@@ -79,3 +79,64 @@ Example `appsettings.json` file.
   },
   //other configs
 ```
+
+#### Exporting Proto.Actor logs to OpenTelemetry collector
+
+OpenTelemetry .NET AutoInstrumentation cannot be used to collect and export the Proto.Actor library logs, since AutoInstrumentation can collect and export logs of .NET `ILogger` only. Proto.Actor uses Serilog for logging, and Serilog is not supported till AutoInstrumentation v1.0.0. Hence, you need to configure the [Serilog OpenTelemetry sink](https://github.com/serilog/serilog-sinks-opentelemetry) explicitly, either through `appsettings.json` or `LoggerConfiguration()`, after importing the latest Serilog OpenTelementry sink library in your project.
+
+```csharp
+<PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="1.1.0" />
+```
+
+```json
+  "Serilog": {
+    "Using": [
+      "Serilog.Exceptions",
+      "Serilog",
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Async"
+    ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "System": "Information",        
+        "Microsoft": "Information",
+        "Microsoft.AspNetCore": "Information",
+        "System.Net.Http.HttpClient": "Information",
+        "Proto.Cluster": "Information",
+        "Proto.Context": "Information",
+        "GossipStateManagement": "Information"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "restrictedToMinimumLevel": "Information",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level}] {Environment} {ApplicationName} {ApplicationVersion} {ServiceId} {ChargePointId}: {Message} {Exception} {NewLine}"
+        }
+      },
+      {
+        "Name": "Async",
+        "Args": {
+          "configure": [
+            {
+              "Name": "OpenTelemetry",
+              "Args": {
+                "Endpoint": "http://localhost:4317",
+                "Protocol": "Grpc",
+                "RestrictedToMinimumLevel": "Information"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithExceptionDetails",
+      "WithMachineName",
+      "WithThreadId"
+    ]
+  }
+```

--- a/hugo/content/docs/metrics.md
+++ b/hugo/content/docs/metrics.md
@@ -108,24 +108,18 @@ Import the latest OpenTelemetry .NET AutoInstrumentation package in your .NET pr
 
 Configure these .NET CLR environment variables, besides the [required ones](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation?tab=readme-ov-file#instrument-a-net-application)
 
-```
-OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES=Proto.Actor
-```
+`OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES=Proto.Actor`
 
 You can even mention any manual `Meter` names above to collect any manual instrumented data from them.
 
 You can either set `Console_Exporter` to `true` or `false`, depending on whether you want to view the instrumented data in the console (for debugging purposes). By default, they are all set to `false`.
 
-```
-OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED=true
-```
+`OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED=true`
 
 You can configure the OpenTelemetry collector endpoint and protocol using the environment variables
 
-```
-OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-```
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317`
+- `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`
 
 #### Word of caution!
 

--- a/hugo/content/docs/metrics.md
+++ b/hugo/content/docs/metrics.md
@@ -94,6 +94,43 @@ void ConfigureMetrics(WebApplicationBuilder builder) =>
 
 ```
 
+### OpenTelemetry .NET AutoInstrumentation
+
+Just as we have discussed about using [OpenTelemetry .NET AutoInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) while collecting [Proto.Actor traces](https://proto.actor/docs/tracing/), you can also collect metrics using it, and hence, no manual metrics builder configuration (like the above code snippet) is required. Besides, you can even use it to collect any manual metrics, if required. All the metrics emitted from the Proto.Actor library correspond to the meter name `Proto.Actor` and hence, once you specify that, all the metrics would be collected.
+
+#### Configurations
+
+Import the latest OpenTelemetry .NET AutoInstrumentation package in your .NET project
+
+```csharp
+<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.0.0" />
+```
+
+Configure these .NET CLR environment variables, besides the [required ones](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation?tab=readme-ov-file#instrument-a-net-application)
+
+```
+OTEL_DOTNET_AUTO_METRICS_ADDITIONAL_SOURCES=Proto.Actor
+```
+
+You can even mention any manual `Meter` names above to collect any manual instrumented data from them.
+
+You can either set `Console_Exporter` to `true` or `false`, depending on whether you want to view the instrumented data in the console (for debugging purposes). By default, they are all set to `false`.
+
+```
+OTEL_DOTNET_AUTO_METRICS_CONSOLE_EXPORTER_ENABLED=true
+```
+
+You can configure the OpenTelemetry collector endpoint and protocol using the environment variables
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+#### Word of caution!
+
+OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentaion before using.
+
 ## Using Prometheus and Grafana to store and visualize metrics
 
 Another example of Prometheus metrics setup might be found in [ActorMetrics example](https://github.com/asynkron/protoactor-dotnet/tree/dev/examples/ActorMetrics).

--- a/hugo/content/docs/tracing.md
+++ b/hugo/content/docs/tracing.md
@@ -80,24 +80,18 @@ Import the latest OpenTelemetry .NET AutoInstrumentation package in your .NET pr
 
 Configure these .NET CLR environment variables, besides the [required ones](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation?tab=readme-ov-file#instrument-a-net-application)
 
-```
-OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=Proto.Actor
-```
+`OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=Proto.Actor`
 
 You can even mention any manual `ActivitySource`s above to collect any manual instrumented data from them.
 
 You can either set `Console_Exporter` to `true` or `false`, depending on whether you want to view the instrumented data in the console (for debugging purposes). By default, they are all set to `false`.
 
-```
-OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED=true
-```
+`OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED=true`
 
 You can configure the OpenTelemetry collector endpoint and protocol using the environment variables
 
-```
-OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-```
+- `OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317`
+- `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`
 
 #### Word of caution!
 

--- a/hugo/content/docs/tracing.md
+++ b/hugo/content/docs/tracing.md
@@ -66,6 +66,43 @@ static void ConfigureTracing(WebApplicationBuilder builder) =>
 
 ```
 
+### OpenTelemetry .NET AutoInstrumentation
+
+Proto.Actor .NET is also compatible with [OpenTelemetry .NET AutoInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation). Just for reference, OpenTelemetry .NET AutoInstrumentation is an open-source tool from OpenTelemetry and is used to instrument the .NET libraries implicitly. You are not required to configure the tracing or metrics builder explicitly (as shown in the above code snippet) any more, and you can even use it alongside manual instrumentation, if required. It relies on the .NET CLR (Common Language Runtime) for its execution. The main reason why Proto.Actor is compatible with the OpenTelemetry .NET AutoInstrumentation is because the `ActivitySourceName` for all the Proto.Actor library traces is `Proto.Actor`, and once you specify that, all the traces would be collected.
+
+#### Configurations
+
+Import the latest OpenTelemetry .NET AutoInstrumentation package in your .NET project
+
+```csharp
+<PackageReference Include="OpenTelemetry.AutoInstrumentation" Version="1.0.0" />
+```
+
+Configure these .NET CLR environment variables, besides the [required ones](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation?tab=readme-ov-file#instrument-a-net-application)
+
+```
+OTEL_DOTNET_AUTO_TRACES_ADDITIONAL_SOURCES=Proto.Actor
+```
+
+You can even mention any manual `ActivitySource`s above to collect any manual instrumented data from them.
+
+You can either set `Console_Exporter` to `true` or `false`, depending on whether you want to view the instrumented data in the console (for debugging purposes). By default, they are all set to `false`.
+
+```
+OTEL_DOTNET_AUTO_TRACES_CONSOLE_EXPORTER_ENABLED=true
+```
+
+You can configure the OpenTelemetry collector endpoint and protocol using the environment variables
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+#### Word of caution!
+
+OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentaion before using.
+
 ### Setup tracing for Proto.Actor
 
 In order to use Proto.OpenTelemetry with Proto.Actor first you need to create actor's Props and call extension method `WithTracing()`.


### PR DESCRIPTION
Updated observability documentation for OpenTelemetry AutoInstrumentation compatibility

[OpenTelemetry .NET AutoInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation) is a recently released open-source tool from OpenTelemetry foundation, and it aims to collect the observability data in .NET application from various .NET libraries without the need to explicitly configure the tracing/metrics builder in the application. 

While using that in my application, I found out that Proto.Actor .NET is also compatible with it, and hence thought of updating the docs, so that other community users can find this useful.