### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Current documentation web-site build with [Hugo](https://gohugo.io/getting-start
 
 1. [Install Hugo locally](https://gohugo.io/getting-started/installing/)
 2. Go to repository folder
-3. Execute `hugo server`. By default site will be availabe at http://localhost:1313/
+3. Execute `hugo server`. By default site will be available at http://localhost:1313/


### PR DESCRIPTION
## Summary
- fix spelling of "available" in README

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_688f98616a2c8328bf1ac37c5a02a7ec