### PR TITLE
docs: correct typographical errors

### DIFF
--- a/hugo/content/docs/bootcamp/unit-3/lesson-2/_index.md
+++ b/hugo/content/docs/bootcamp/unit-3/lesson-2/_index.md
@@ -284,7 +284,7 @@ public Task ReceiveAsync(IContext context)
 }
 ```
 
-And let's implement method `ProcessStoppingMessage()` . This methos be will display a stop message on the console.
+And let's implement method `ProcessStoppingMessage()` . This method will display a stop message on the console.
 
 ```csharp
 private void ProcessStoppingMessage(Stopping msg)

--- a/hugo/content/docs/bootcamp/unit-3/lesson-4/_index.md
+++ b/hugo/content/docs/bootcamp/unit-3/lesson-4/_index.md
@@ -74,7 +74,7 @@ Let's replace `Poison()` call with `Stop()` and lunch our app to see what happen
 
 ![](../../images/3_4_2.png)
 
-As you can see, the actor succesfully completed job. 
+As you can see, the actor successfully completed job.
 
 {{< listfiles "dotnet" >}}
 

--- a/hugo/content/docs/bootcamp/unit-4/_index.md
+++ b/hugo/content/docs/bootcamp/unit-4/_index.md
@@ -10,7 +10,7 @@ You will also learn what a supervisor is and what actor-recovery strategies the 
 
 1. [Supervisor and actor hierarchy.](lesson-1)
 2. [Overview of the application that demonstrates the supervisor's capabilities and the actors hierarchy.](lesson-2)
-3. [Actor's addres and PID.](lesson-3)
+3. [Actor's address and PID.](lesson-3)
 4. [Creating UserCoordinatorActor.](lesson-4)
 5. [Creating MoviePlayCounterActor.](lesson-5)
 6. [How parent actors are watching over their children actors.](lesson-6)

--- a/hugo/content/docs/bootcamp/unit-4/lesson-2/_index.md
+++ b/hugo/content/docs/bootcamp/unit-4/lesson-2/_index.md
@@ -16,7 +16,7 @@ We also have a couple of messages `PlayMovieMessage()` and `StopMovieMessage()`.
 
 ![](../../images/4_2_3.png)
 
-These messages have a UserId, and when they fall into `UserCoordinatorActor ()`, `UserCoordinatorActor ()` will check if there is no suitable instance of `UserActor()` for this UserId, then `UserCoordinatorActor()` will create  apropriate `UserActor()`. And Next `UserCoordinatorActor ()` will send messages to the desired `UserActor()` to start or stop playback of the movie.
+These messages have a UserId, and when they fall into `UserCoordinatorActor ()`, `UserCoordinatorActor ()` will check if there is no suitable instance of `UserActor()` for this UserId, then `UserCoordinatorActor()` will create  appropriate `UserActor()`. And Next `UserCoordinatorActor ()` will send messages to the desired `UserActor()` to start or stop playback of the movie.
 
 ![](../../images/4_2_4.png)
 

--- a/hugo/content/docs/chatexample/_index.md
+++ b/hugo/content/docs/chatexample/_index.md
@@ -112,7 +112,7 @@ In the next couple of sections, we are going to dissect it piece by piece.
 
 ### Creating an Actor System
 
-First we need to intialize and start our actor system and remote which is acomplished by following lines of code located in `InitializeActorSystem` method in the server assembly.
+First we need to initialize and start our actor system and remote which is accomplished by following lines of code located in `InitializeActorSystem` method in the server assembly.
 {{< tabs >}}
 {{< tab "C#" >}}
 
@@ -224,7 +224,7 @@ where you can see that the client side is a tad bit more involved, but nothing t
 
 ### Creating an Actor System
 
-Same as before, we will intialize and start our actor system and remote.
+Same as before, we will initialize and start our actor system and remote.
 {{< tabs >}}
 {{< tab "C#" >}}
 

--- a/hugo/content/docs/cluster.md
+++ b/hugo/content/docs/cluster.md
@@ -26,7 +26,7 @@ This allows us to create huge clusters of stateful services where the virtual ac
 
 This offers us a unique way to optimize for data locality, while still offering ease of use at scale.
 
-Just like everything else in Proto.Actor where we have re-used proven technologies such as Protobuf and gRPC, we do the same for clustering, we do not reinvent the wheel and create our own cluster mechanics.
+Just like everything else in Proto.Actor where we have reused proven technologies such as Protobuf and gRPC, we do the same for clustering, we do not reinvent the wheel and create our own cluster mechanics.
 Instead, we leverage proven technologies such as Consul, ETCD or Kubernetes to power our Cluster member management.
 
 The short version of what virtual actors are, is that they are abstractions on top of plain actors.

--- a/hugo/content/docs/cluster/cluster-providers-net.md
+++ b/hugo/content/docs/cluster/cluster-providers-net.md
@@ -11,7 +11,7 @@ Main responsibilities of cluster provider is to add new member into a cluster, m
 
 ![Cluster provider](images/cluster-provider.jpg)
 
-Proto.Actor continues philosophy of not reinventing the wheel again, so it is possible to choose between one of already battle tested compontents that provide these functionalities.
+Proto.Actor continues philosophy of not reinventing the wheel again, so it is possible to choose between one of already battle tested components that provide these functionalities.
 
 Available providers:
 
@@ -19,10 +19,10 @@ Available providers:
 - [Consul Provider](consul-net.md)
 - [Amazon ECS Provider](aws-provider-net.md)
 - [Test Provider](test-provider-net.md)
-- ETCD Provier
+- ETCD Provider
 - Zookeeper Provider
-- Self Managed Provider - your own implementaion of [`IClusterProvider`](https://github.com/asynkron/protoactor-dotnet/blob/dev/src/Proto.Cluster/IClusterProvider.cs) interface
+- Self Managed Provider - your own implementation of [`IClusterProvider`](https://github.com/asynkron/protoactor-dotnet/blob/dev/src/Proto.Cluster/IClusterProvider.cs) interface
 
 ## Cluster Client
 
-Cluster client is an abstraction that gives possibility to send messages to actors in a cluster. In most cases, cluster member is also a cluster client, but in some scenarios these components are splitted. In these cases, cluster provider has possibility to start only the cluster client.
+Cluster client is an abstraction that gives possibility to send messages to actors in a cluster. In most cases, cluster member is also a cluster client, but in some scenarios these components are split. In these cases, cluster provider has possibility to start only the cluster client.

--- a/hugo/content/docs/cluster/getting-started-kubernetes.md
+++ b/hugo/content/docs/cluster/getting-started-kubernetes.md
@@ -60,7 +60,7 @@ The same in the `SmartBulbSimulatorApp`
 services.AddActorSystem(hostContext.Configuration);
 ```
 
-At this step both applications should be ready to run in Kubernetes, but first we need to create conainter images.
+At this step both applications should be ready to run in Kubernetes, but first we need to create container images.
 
 ## Create docker images
 

--- a/hugo/content/docs/cluster/getting-started-net.md
+++ b/hugo/content/docs/cluster/getting-started-net.md
@@ -247,7 +247,7 @@ To avoid confusion, in this tutorial we'll refer to virtual actors as grains.
 To recap:
 
 1. Grains are essentially actors, meaning they will process messages one at a time.
-1. Grains are not explicitly crated (activated). Instead, they are created when they receive the first message.
+1. Grains are not explicitly created (activated). Instead, they are created when they receive the first message.
 1. Each grain lives in _one_ of the cluster members.
 1. Grain's location is transparent, meaning we don't need to know in which cluster member grain lives to call it.
 1. Communication with grains should almost always be a request/response.

--- a/hugo/content/docs/cluster/partition-idenity-lookup.md
+++ b/hugo/content/docs/cluster/partition-idenity-lookup.md
@@ -9,7 +9,7 @@ The main feature of this strategy is to split responsibility of owning actor's i
 
 The identity owner member is assigned with a consistent hashing algorithm, while placement is determined with a [member strategy](member-strategies.md).
 
-![Parition Identity Lookup](images/partition-identity-lookup.jpg)
+![Partition Identity Lookup](images/partition-identity-lookup.jpg)
 
 When cluster topology changes (members are leaving or joining the cluster), the partitioned identities need to be rebalanced, because identity ownership changes (according to the consistent).
 

--- a/hugo/content/docs/cluster/pub-sub.md
+++ b/hugo/content/docs/cluster/pub-sub.md
@@ -116,7 +116,7 @@ cluster.Unsubscribe("my-topic", ClusterIdentity.Create("my-id", "my-kind"));
 ### What if I forget to unsubscribe?
 
 If you stop the subscriber without first unsubscribing from the topic, two different situations may occur depending on whether virtual or regular actors are used:
-* When using virtal actors, they are assumed to always exist. If there is no activation available currently, the framework will spawn one when a message arrives to this actor. So a message published to the topic will activate the virtual actor again.
+* When using virtual actors, they are assumed to always exist. If there is no activation available currently, the framework will spawn one when a message arrives to this actor. So a message published to the topic will activate the virtual actor again.
 * Regular actors have an explicit lifecycle. If you stop such actor, all messages directed to it will end up in the deadletter process. When this situation is detected, the subscriber will get automatically unsubscribed. It is still recommended to unsubscribe explicitly.
 
 ## Persistent subscriptions

--- a/hugo/content/docs/cluster/test-provider-net.md
+++ b/hugo/content/docs/cluster/test-provider-net.md
@@ -4,7 +4,7 @@ title: Test cluster provider (.NET)
 
 # Test provider
 
-The esiest way to run clustered Proto.Actor setup during developemnt on local machine (without using real clustering) is to use Test Cluster Provider.
+The easiest way to run clustered Proto.Actor setup during development on local machine (without using real clustering) is to use Test Cluster Provider.
 
 This might be used together with other provider, e.g. in dev environment use test provider otherwise use production one. Example might be found in [Realtime map example](https://github.com/asynkron/realtimemap-dotnet/blob/main/Backend/ProtoActorExtensions.cs#L75).
 

--- a/hugo/content/docs/cluster/using-cluster-net.md
+++ b/hugo/content/docs/cluster/using-cluster-net.md
@@ -190,7 +190,7 @@ services.AddSingleton(provider =>
 });
 ```
 
-For convinience, you can also register a `Cluster` object:
+For convenience, you can also register a `Cluster` object:
 
 ```csharp
 services.AddSingleton(provider => provider

--- a/hugo/content/docs/clusterintro/_index.md
+++ b/hugo/content/docs/clusterintro/_index.md
@@ -279,7 +279,7 @@ cluster
 
 #### PongerActor
 
-`protos_protoactor.go` contains a Ponger.Actor struct in it, which receives the incoming message and makes a method call to the corresponding interface method from the IDL definition, or simply proxies the message to a defaut message receive method. A developer only has to provide such methods by providing Ponger implementation.
+`protos_protoactor.go` contains a Ponger.Actor struct in it, which receives the incoming message and makes a method call to the corresponding interface method from the IDL definition, or simply proxies the message to a default message receive method. A developer only has to provide such methods by providing Ponger implementation.
 
 ![Ponger Actor](requests.png)
 


### PR DESCRIPTION
## Summary
- fix typos across Bootcamp, Chat example, and cluster documentation
- standardize wording in multiple markdown guides

## Testing
- `codespell -q 3 -L aks` *(reported remaining `re-use` and `recieve` warnings in clusterintro/_index.md)*

------
https://chatgpt.com/codex/tasks/task_e_688f99aff5808328ac991ee4f6dfd5af