### PR TITLE
Fix spelling errors in documentation

### DIFF
--- a/hugo/content/docs/clusterintro/_index.md
+++ b/hugo/content/docs/clusterintro/_index.md
@@ -298,7 +298,7 @@ type Ponger interface {
 }
 ```
 
-A common method for initialization – `Init()` – is already implemented by `cluster.Grain` so a `Ponger` implementation can re-use this by embedding cluster.Grain as below:
+A common method for initialization – `Init()` – is already implemented by `cluster.Grain` so a `Ponger` implementation can reuse this by embedding cluster.Grain as below:
 
 ```go
 type ponger struct {
@@ -306,7 +306,7 @@ type ponger struct {
 }
 ```
 
-However, `Terminate()`, `ReceiveDefault()` and `Ping()` still need to be implemented by a developer. `Terminate()` is called on passivation right before PongerActor stops and hence the subordinating ponger instance also must stop. `ReceiveDefault()` is a method to receive any message that are not expected to be handled in gRPC-like manner; `Ping()` is a method to recieve `PingMessage` and return `PongMessage` in gRPC-like manner.
+However, `Terminate()`, `ReceiveDefault()` and `Ping()` still need to be implemented by a developer. `Terminate()` is called on passivation right before PongerActor stops and hence the subordinating ponger instance also must stop. `ReceiveDefault()` is a method to receive any message that are not expected to be handled in gRPC-like manner; `Ping()` is a method to receive `PingMessage` and return `PongMessage` in gRPC-like manner.
 
 ```go
 type ponger struct {

--- a/hugo/content/docs/context.md
+++ b/hugo/content/docs/context.md
@@ -52,7 +52,7 @@ Provides the ability to spawn new actors given a `Props` parameter.
 
 *Implemented by* `RootContext`, `ActorContext`
 
-Provides the ability to immediatly stop an actor, or instruct it to stop after processing current mailbox messages.
+Provides the ability to immediately stop an actor, or instruct it to stop after processing current mailbox messages.
 
 {{< tabs >}}
 {{< tab "C#" >}}

--- a/hugo/content/docs/eventstream.md
+++ b/hugo/content/docs/eventstream.md
@@ -11,7 +11,7 @@ The EventStream is used internally in Proto.Actor to broadcast framework events.
     graph LR
     sender(Sender)
     class sender blue
-    message(Messag)
+    message(Message)
     class message message
     es(EventStream)
     class es blue

--- a/hugo/content/docs/life-cycle.md
+++ b/hugo/content/docs/life-cycle.md
@@ -330,7 +330,7 @@ public Task ReceiveAsync(IContext context)
 }
 ```
 
-And let's implement method `ProcessStoppingMessage()` . This methos be will display a stop message on the console.
+And let's implement method `ProcessStoppingMessage()` . This method will display a stop message on the console.
 
 ```csharp
 private void ProcessStoppingMessage(Stopping msg)

--- a/hugo/content/docs/messages/poison-pill.md
+++ b/hugo/content/docs/messages/poison-pill.md
@@ -58,7 +58,7 @@ Let's launch our app and see what happened.
 
 ![](images/3_4_1.png)
 
-Let's replace `Poison()` call with `Stop()` and lunch our app to see what happened.
+Let's replace `Poison()` call with `Stop()` and launch our app to see what happened.
 
 ```diff
 - system.Root.Poison(pid);
@@ -67,7 +67,7 @@ Let's replace `Poison()` call with `Stop()` and lunch our app to see what happen
 
 ![](images/3_4_2.png)
 
-As you can see, the actor succesfully completed job.
+As you can see, the actor successfully completed job.
 
 {{< listfiles "dotnet" >}}
 

--- a/hugo/content/docs/metrics.md
+++ b/hugo/content/docs/metrics.md
@@ -72,9 +72,9 @@ This extension is using builder pattern to properly configure `MeterProvider` wi
 Prometheus exporter built-in in the application is the easiest to setup and it will be shown as an example. It is needed to reference `OpenTelemetry.Exporter.Prometheus` nuget package and call `AddPrometheusExporter()` extension method.
 It adds `/metrics` endpoint from where Prometheus is able to scrape metrics. To make it work properly it is needed to call also `app.UseOpenTelemetryPrometheusScrapingEndpoint()` after building an application.
 
-`OpenTelemetry` metrics in C# implementation use [System.Diagnositcs.Metrics](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation).
+`OpenTelemetry` metrics in C# implementation use [System.Diagnostics.Metrics](https://docs.microsoft.com/en-us/dotnet/core/diagnostics/metrics-instrumentation).
 `AddProtoActorInstrumentation()` extension shown in the example is adding Proto.Actor meter name.
-Method has additional parameter `useRecommendedHistogramBoundaries` which is true by default. It causes that default buckets used in OpenTelemetry implementation are changed to more preffered ones.
+Method has additional parameter `useRecommendedHistogramBoundaries` which is true by default. It causes that default buckets used in OpenTelemetry implementation are changed to more preferred ones.
 
 ```csharp
 void ConfigureMetrics(WebApplicationBuilder builder) =>
@@ -123,7 +123,7 @@ You can configure the OpenTelemetry collector endpoint and protocol using the en
 
 #### Word of caution!
 
-OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentaion before using.
+OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentation before using.
 
 ## Using Prometheus and Grafana to store and visualize metrics
 

--- a/hugo/content/docs/money-transfer-saga/_index.md
+++ b/hugo/content/docs/money-transfer-saga/_index.md
@@ -70,10 +70,10 @@ One situation that presents a problem is when we receive no reply to our request
 What if a compensating action fails? 
   
 ### Escalation 
-In the preceding section we descovered scenarios where we are not sure what state the system is in. Even with retries and compensating actions, things can still go wrong. In an ideal world, these should be very rare! However, they can occur and in these cases it's best to have a fallback strategy, escalating the result of the saga to something else, quite possibly a manual / human process. 
+In the preceding section we discovered scenarios where we are not sure what state the system is in. Even with retries and compensating actions, things can still go wrong. In an ideal world, these should be very rare! However, they can occur and in these cases it's best to have a fallback strategy, escalating the result of the saga to something else, quite possibly a manual / human process.
    
-### Atomicitiy
-One thing a saga does not provide is atomicitiy. In the bank account example above there's nothing to stop other systems interacting with the accounts in-between the debit and the credit operations. This needs bearing in mind as it could rule out the saga pattern for some types of operations.
+### Atomicity
+One thing a saga does not provide is atomicity. In the bank account example above there's nothing to stop other systems interacting with the accounts in-between the debit and the credit operations. This needs bearing in mind as it could rule out the saga pattern for some types of operations.
   
 ___
   
@@ -802,4 +802,4 @@ RESULTS for 99.99% uptime, 0.01% chance of refusal, 0.01% of being busy and 0 re
 
 Overall the results show the importance of retrying our operations, and the need to have idempotent receivers that enable us to retry. We can get very good results with very failure prone systems if we simply retry our operations. 
 
-This is of cource an artificial scenario. In the real world, you'd want more subtle retry strategies that allow remote services to recover from high demand they might be experiencing or failures that might be transient - exponential back-off strategies are more useful than immediate retries. The ability to be able to resume a saga from a given point through the use of an audit log is also very important - if a remote service is down for a considerable amount of time you can still attempt the saga when it has recovered.
+This is of course an artificial scenario. In the real world, you'd want more subtle retry strategies that allow remote services to recover from high demand they might be experiencing or failures that might be transient - exponential back-off strategies are more useful than immediate retries. The ability to be able to resume a saga from a given point through the use of an audit log is also very important - if a remote service is down for a considerable amount of time you can still attempt the saga when it has recovered.

--- a/hugo/content/docs/performance/dotnetos.md
+++ b/hugo/content/docs/performance/dotnetos.md
@@ -1,15 +1,15 @@
 # Performance review by Dotnetos
 
-In february 2022, The Dotnetos teams made a performance review of the Proto.Actor .NET core features.
+In February 2022, The Dotnetos teams made a performance review of the Proto.Actor .NET core features.
 This document contains the findings from this review.
 
 Output of [Proto.Actor benchmarks](https://gist.github.com/rogeralsing/12d16983f9d2e27d7c4b39cd25a64b18), with full PGO on and off, to identify any visible quick wins with "measure first approach". It includes both dotMemory and dotTrace profiling. I've also made an initial code "look around".
 
 ## Spawn benchmark
 
-It's mostly allocating 1GB of `ConcurrentQueueSegment` because `ConcurrentQueue` used underneath initialzed by default with 32 such blocks, which is then multiplied 1M times (per every actor).
+It's mostly allocating 1GB of `ConcurrentQueueSegment` because `ConcurrentQueue` used underneath initialized by default with 32 such blocks, which is then multiplied 1M times (per every actor).
 
-That's a litte suprising consequence of using `ConcurrentQueue` but for 1M it's probably ok!
+That's a little surprising consequence of using `ConcurrentQueue` but for 1M it's probably ok!
 
 There are little suboptimal allocations like below but I'm not sure if it is worth to remove them (one is from the benchmark itself):
 
@@ -100,27 +100,27 @@ public int NumberOfFailures(TimeSpan? within)
 ```
 
 {{< note >}}
-This issue have been corrected after the review
+This issue has been corrected after the review
 {{</ note >}}
 
-Additionaly, a few trivial things:
+Additionally, a few trivial things:
 
 - `NullReferenceException` thrown 150 times from `ActorContext.SendUserMessage`? ![Actor](../images/perf7.png)
 - I'd consider moving to [Compile-time logging source generation](https://docs.microsoft.com/en-us/dotnet/core/extensions/logger-message-generator) or [string interpolation](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/), for example in `Proto.OneForOneStrategy.HandleFailure.LogInfo`
 
 ## Remote benchmark
 
-First of all, the previous fix allows to avoid hundreds of MBs of `WaitCallback` allocations that come from `RemoreMessageHandler.HandleRemoteMessage`.
+First of all, the previous fix allows to avoid hundreds of MBs of `WaitCallback` allocations that come from `RemoteMessageHandler.HandleRemoteMessage`.
 
 {{< note >}}
-This issue have been corrected after the review
+This issue has been corrected after the review
 {{</ note >}}
 
-Besides that, much more data ia allocated because of materializing `MessageEnvelope`, to the extent when looking at anything else does not make sense:
+Besides that, much more data is allocated because of materializing `MessageEnvelope`, to the extent when looking at anything else does not make sense:
 
 ![Actor](../images/perf8.png)
 
-The only thought I have in such scenario is - is it possible to get rid of `object`/`class` in some paths (like sending) and use `ref struct` instead? I've skimmed through code and it obviously require much work. I'm not able to propose anything for now here... But well, I have a feeling it won't be ever possible because of Protobuf ane the whole architecture.
+The only thought I have in such scenario is - is it possible to get rid of `object`/`class` in some paths (like sending) and use `ref struct` instead? I've skimmed through code and it obviously require much work. I'm not able to propose anything for now here... But well, I have a feeling it won't be ever possible because of Protobuf and the whole architecture.
 
 ## Cluster benchmark
 

--- a/hugo/content/docs/persistence-proto-persistence.md
+++ b/hugo/content/docs/persistence-proto-persistence.md
@@ -134,7 +134,7 @@ Here we are using the static `WithSnapshotting` method to create the `Persistenc
 ## Event Sourcing and Snapshotting
 
 We can use both event sourcing and snapshotting together. When used in this manner, snapshotting becomes a performance optimisation for cases when you have large numbers of events to replay to rebuild the state of your actor.
-When `RecoverStateAsync` is called, if there are any snapshots saved, then the most recent one will be loaded along with any events that occured _after_ the snapshot was taken.
+When `RecoverStateAsync` is called, if there are any snapshots saved, then the most recent one will be loaded along with any events that occurred _after_ the snapshot was taken.
 The `Persistence` plugin manages this tracking internally through the use of an index that is incremented for each saved event. Any time a snapshot is taken, it is tied to index of the actor at that time.
 
 We can rewrite the `Counter` example above to use event sourcing with snapshotting:

--- a/hugo/content/docs/tracing.md
+++ b/hugo/content/docs/tracing.md
@@ -95,7 +95,7 @@ You can configure the OpenTelemetry collector endpoint and protocol using the en
 
 #### Word of caution!
 
-OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentaion before using.
+OpenTelemetry .NET AutoInstrumentation works only with `System.Diagnostics.DiagnosticSource` version of 8.0.0 or more, and `.NET` framework version of 4.6.2 or more. Hence, request you to go through their detailed documentation before using.
 
 ### Setup tracing for Proto.Actor
 


### PR DESCRIPTION
## Summary
- correct typos across multiple docs
- improve clarity in actor and saga examples

## Testing
- `hugo --minify`
- `codespell -q 3 --skip="*.js,*.css,*.svg,*.png,*.jpg,*.jpeg,*.gif,*.pdf,*.json,*.toml,*.yml,*.yaml,*.drawio,*.map,*.html" -L aks -f ./`


------
https://chatgpt.com/codex/tasks/task_e_688f9c03604883288bfc5fe29480dc03