### PR TITLE
docs: sync with latest protoactor-dotnet changes

### DIFF
--- a/hugo/content/docs/cluster.md
+++ b/hugo/content/docs/cluster.md
@@ -170,13 +170,17 @@ To recap:
 - Then it was spawned as an actor on Member 2.
 - When Member 2 went down, it was spawned on Member 1 as a different actor.
 
-In none of the above situations, we had to care about its state, location, or even existence. Under the hood, Proto.Cluster took care of that details. This is the reason, why grains are sometimes called _virtual_ actors.
+In none of the above situations did we have to care about its state, location, or even existence. Under the hood, Proto.Cluster took care of those details. This is the reason why grains are sometimes called _virtual_ actors.
 
 ### Shutting down a grain
 
-Grains are created automatically, however there is no mechanism out of the box in Proto.Actor that would garbage collect them. To stop the grain you can:
-* stop it in reaction to some event that should terminate its lifetime (e.g. user has disconnected from a game, so there is no need to track them anymore)
-* set the `ReceiveTimeout` on the grain that will detect inactivity, then react to the timeout message by poisoning the grain
+Grains are created automatically; however, there is no mechanism out of the box in Proto.Actor that would garbage collect them. To stop a grain you can:
+* stop it in reaction to an event that should terminate its lifetime (e.g., a user disconnects from a game and no longer needs to be tracked)
+* set `ReceiveTimeout` on the grain to detect inactivity, then react to the timeout message by poisoning the grain
+
+### Activation statistics
+
+Proto.Cluster records basic activation metrics for each grain. Recent updates also track how many times a grain has started, enabling operators to spot repeated restarts or thrashing.
 
 ## Cluster Identity
 

--- a/hugo/content/docs/cluster/pub-sub.md
+++ b/hugo/content/docs/cluster/pub-sub.md
@@ -141,7 +141,7 @@ This topic kind registration overrides the default one in the cluster.
 
 ## BatchingProducer
 
-The delivery of the messages can be optimized by sending them in batches. `BatchingProducer` will help you create message batches in scenarios, where you have multiple publishers publishing to single topic. The batching producer will collect messages from different sources, group them in batches, and send to subscribers.
+Message delivery can be optimized by sending messages in batches. `BatchingProducer` helps create batches when multiple publishers target a single topic. The batching producer collects messages from different sources, groups them, and then sends each batch to subscribers.
 
 ```mermaid
 flowchart LR
@@ -185,9 +185,11 @@ var t2 = producer.ProduceAsync(new ChatMessage { Message = "Hi" });
 await Task.WhenAll(t1, t2);
 ```
 
-Notice how the produce tasks are not awaited in a sequence, but rather all at once. This is the pattern you should follow when using the BatchingProducer. The tasks will complete when the message is actually delivered to the topic, not when added to the internal producer queue.
+Notice how the produce tasks are awaited together instead of sequentially. This pattern ensures that work is parallelized and each task completes only after the message is delivered to the topic, not merely queued internally.
 
 *Note: you can also decide to not await the task if you are interested in the "fire and forget" scenario.*
+
+Disposing the producer stops the internal loop gracefully. Recent updates avoid channel closed exceptions when the producer shuts down.
 
 ### Cancel a message
 

--- a/hugo/content/docs/logging.md
+++ b/hugo/content/docs/logging.md
@@ -6,14 +6,15 @@ title: Logging
 
 ## Configuring logging on .NET
 
-In Proto.Actor .NET, Logging is configured via the static `Proto.Log` setting.
+In Proto.Actor .NET, logging is configured through the static `Proto.Log` class.
+Earlier releases briefly marked this logger as obsolete, but it has been restored and remains the recommended entry point.
 
 ### Using console
 
 ```csharp
 public static void SetupLogger()
 {
-    //Configure ProtoActor to use Console logger
+    // Configure Proto.Actor to use the console logger
     Proto.Log.SetLoggerFactory(
         LoggerFactory.Create(l => l.AddConsole().SetMinimumLevel(LogLevel.Error)));
 }
@@ -24,10 +25,10 @@ public static void SetupLogger()
 ```csharp
 public static void SetupLogger()
 {
-    //Configure SeriLog
+    // Configure Serilog
     Log.Logger = new LoggerConfiguration().WriteTo.Console(LogEventLevel.Error).CreateLogger();
-    
-    //Configure ProtoActor to use Serilog
+
+    // Configure Proto.Actor to use Serilog
     Proto.Log.SetLoggerFactory(
         LoggerFactory.Create(l => l.AddSerilog().SetMinimumLevel(LogLevel.Error)));
 }


### PR DESCRIPTION
## Summary
- clarify that `Proto.Log` remains the recommended logging entry point
- document graceful shutdown of `BatchingProducer`
- note new activation metrics including grain start count

## Testing
- `hugo -s hugo`

------
https://chatgpt.com/codex/tasks/task_e_68972b6d6b608328a431ec0ebc732f7a