### PR TITLE
docs: explain queues vs actors and comparison guides

### DIFF
--- a/hugo/content/docs/_index.md
+++ b/hugo/content/docs/_index.md
@@ -30,6 +30,8 @@ tags: [protoactor, docs]
 - [Actor lifecycle](life-cycle.md)
 - [Location Transparency](location-transparency.md)
 - [Message Delivery Reliability](durability.md)
+- [Actors vs Queues and Logs](actors-vs-queues.md) - When to pick real-time actors vs durable messaging
+- [Backpressure and Flow Control](backpressure.md)
 
 ## Building Blocks
 
@@ -120,4 +122,5 @@ tags: [protoactor, docs]
 ## Additional Information
 
 - [Core vs contrib Proto.Actor components](core-contrib-components.md)
+- [Proto.Actor vs Erlang and Akka](protoactor-vs-erlang-akka.md)
 - [Books](books.md)

--- a/hugo/content/docs/actors-vs-queues.md
+++ b/hugo/content/docs/actors-vs-queues.md
@@ -1,0 +1,31 @@
+---
+title: "Actors vs Queues and Logs"
+date: 2025-08-09
+draft: false
+tags: [actors, queues, logs]
+---
+
+# Actors vs Queues and Logs
+
+Actors excel at managing in-memory state and orchestrating concurrent work. Their mailboxes are ephemeral and rely on best-effort delivery. If a process crashes, in-flight messages may be lost. For workflows that demand durable delivery, ordering or exactly-once processing, a dedicated queue or log is the safer option.
+
+## Real-time vs durable messaging
+
+Actors pass messages directly in memory and can react in microseconds. This makes them ideal for real-time workloads such as multiplayer games or IoT device coordination where even small delays are unacceptable. Queues and logs persist to disk and replicate data, adding milliseconds of latency. They are "realtime-ish": great for reliability, but they cannot meet ultra low-latency requirements.
+
+## When to choose actors
+
+- Coordinating in-memory state and behaviour
+- Performing lightweight or transient tasks
+- Reacting to messages where occasional loss is acceptable
+
+## When to choose a queue or log
+
+- You need at-least-once or exactly-once guarantees
+- Messages must survive process restarts or crashes
+- Work needs to be distributed over time or across many consumers
+
+Queues (e.g. RabbitMQ) and logs (e.g. Kafka) store messages durably and let consumers reprocess them if needed. Proto.Actor can integrate with these systems, but the queue or log remains the source of truth. Actors should focus on domain behaviour, while the messaging infrastructure provides reliability.
+
+In short: not everything should be actor based. If your scenario requires strong delivery guarantees and can tolerate extra latency, persist the messages in a queue or log first and let actors pull work from there. Conversely, when ultra low latency is essential, keep the work in memory and lean on actors.
+

--- a/hugo/content/docs/backpressure.md
+++ b/hugo/content/docs/backpressure.md
@@ -1,0 +1,23 @@
+---
+title: "Backpressure and Flow Control"
+date: 2025-08-09
+draft: false
+tags: [actors, backpressure]
+---
+
+# Backpressure and Flow Control
+
+A common misconception is that actor systems automatically handle unlimited message rates. In reality, every actor has finite processing capacity. Unbounded mailboxes may lead to increased memory usage and eventually to process failure.
+
+## Strategies inside Proto.Actor
+
+- **Bounded mailboxes** limit how many messages an actor can queue.
+- **Throttling** or **work pulling** lets actors request work only when ready.
+- **Batching** aggregates many messages into one processing unit.
+
+## When external queues help
+
+If producers outrun consumers for extended periods, or if you need durable buffering, place a persistent queue or log in front of the actor system. The queue provides storage and delivery guarantees while actors handle the business logic once they are ready to consume messages.
+
+Backpressure is about matching the rate of production to the rate of consumption. Use actors for behaviour and concurrency, but rely on queues or logs when you need durable, elastic buffering.
+

--- a/hugo/content/docs/protoactor-vs-erlang-akka.md
+++ b/hugo/content/docs/protoactor-vs-erlang-akka.md
@@ -1,0 +1,26 @@
+---
+title: "Proto.Actor vs Erlang and Akka"
+date: 2025-08-09
+draft: false
+tags: [actors, erlang, akka]
+---
+
+# Proto.Actor vs Erlang and Akka
+
+Proto.Actor builds on ideas popularised by Erlang/OTP and Akka but aims to provide a minimal, cross-language runtime.
+
+## Similarities
+
+- **Actor model**: all three use message passing, supervision and isolation.
+- **Failure handling**: supervisors restart failed actors instead of sharing memory.
+
+## Differences
+
+- **Language support**: Erlang targets the BEAM VM; Akka focuses on JVM and Scala/Java; Proto.Actor provides implementations for .NET and Go with similar APIs.
+- **Minimalism**: Proto.Actor intentionally keeps the core small. Features such as persistence or clustering are optional packages, whereas Akka and Erlang ship with many batteries included.
+- **Ecosystem**: Erlang and Akka have decades of libraries built around their runtimes. Proto.Actor emphasises portability and interoperability across languages.
+
+## Choosing a framework
+
+If you already rely heavily on the BEAM or JVM ecosystems, Erlang or Akka may offer richer tooling. Proto.Actor is a good fit when you need a lightweight actor runtime in .NET or Go that can integrate with existing message queues, logs or services.
+


### PR DESCRIPTION
## Summary
- document when to choose actors versus durable queues or logs, emphasizing real-time, low-latency use cases like games or IoT
- add guidance on backpressure and flow control
- compare Proto.Actor with Erlang and Akka

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_6897321ae03c8328b26896837fe005b8