### PR TITLE
Unify CAP docs and expand actor patterns

### DIFF
--- a/hugo/content/docs/_index.md
+++ b/hugo/content/docs/_index.md
@@ -25,11 +25,14 @@ tags: [protoactor, docs]
 
 - [What is an Actor?](actors.md)
 - [What is a Message?](messages.md)
+- [Actor Communication](communication.md)
 - [Terminology, Concepts](terminology.md)
 - [Supervision and Monitoring](supervision.md)
+- [Fault Tolerance](fault-tolerance.md)
 - [Actor lifecycle](life-cycle.md)
 - [Location Transparency](location-transparency.md)
 - [Message Delivery Reliability](durability.md)
+- [Message Patterns](message-patterns.md)
 - [Actors vs Queues and Logs](actors-vs-queues.md) - When to pick real-time actors vs durable messaging
 - [Backpressure and Flow Control](backpressure.md)
 - [Consistency Models](consistency-models.md)
@@ -114,6 +117,8 @@ tags: [protoactor, docs]
 
 ## Useful Patterns
 
+- [Ask Pattern](ask-pattern.md)
+- [Idempotency in Messaging](idempotency.md)
 - [Message Throttling](throttling.md)
 - [Work Pulling Pattern](work-pulling.md)
 - [Limit Concurrency](limit-concurrency.md)

--- a/hugo/content/docs/ask-pattern.md
+++ b/hugo/content/docs/ask-pattern.md
@@ -1,0 +1,19 @@
+---
+title: "Ask Pattern"
+date: 2025-08-09T00:00:00Z
+draft: false
+tags: [protoactor, docs]
+---
+# Ask Pattern
+
+The ask pattern provides request–response semantics between actors. An actor sends a message and waits for a reply, typically by using a future or awaiting a `Task`.
+
+In Proto.Actor you can use `Context.Request` when the sender expects the recipient to know who sent the message. For an awaitable response, `Context.RequestAsync<T>` or `PID.RequestAsync<T>` returns a `Task<T>` that completes when the reply arrives.
+
+```csharp
+var response = await pid.RequestAsync<MyReply>(new MyRequest());
+```
+
+Because the actor thread is released while waiting, combine the ask pattern with [Reentrancy](reenter.md) to avoid blocking the actor. For fire‑and‑forget messaging, prefer `Context.Send`.
+
+See [Actor Communication](communication.md) for an overview of messaging APIs and [PID](pid.md) for additional request options.

--- a/hugo/content/docs/cap-theorem.md
+++ b/hugo/content/docs/cap-theorem.md
@@ -6,16 +6,16 @@ tags: [protoactor, docs]
 ---
 # CAP Theorem
 
-The CAP theorem states that in the presence of a network partition a distributed system can provide either consistency or availability, but not both simultaneously.
+The CAP theorem states that in the presence of a network partition a distributed system can provide either consistency or availability, but not both simultaneously. For an overview of consistency trade‑offs, see [Consistency Models](consistency-models.md).
 
 ## Consistency
-Reads return the most recent write. Choosing consistency often requires coordination and may lead to unavailability if partitions occur.
+Reads return the most recent write. Choosing consistency often requires coordination—for example via [Consensus and Leader Election](consensus.md)—and may lead to unavailability if partitions occur.
 
 ## Availability
 Every request receives a response, even if it may not be the latest data. Systems that favor availability handle partitions by serving stale data and reconciling later.
 
 ## Partition Tolerance
-Network failures happen. Proto.Actor embraces this by allowing actors to recover, replay events and rebuild state when partitions heal.
+Network failures happen. Proto.Actor embraces this by allowing actors to recover, replay events and rebuild state when partitions heal; see [Cluster Partitions](cluster-partitions.md) for strategies that keep actors reachable.
 
 ## Working with CAP in Proto.Actor
-Proto.Actor does not dictate where you land on the CAP spectrum. Instead it provides primitives—like persistence, clustering and message passing—so you can build systems that choose consistency or availability depending on business requirements.
+Proto.Actor does not dictate where you land on the CAP spectrum. Instead it provides primitives—like persistence, clustering and message passing—so you can build systems that choose consistency or availability depending on business requirements. Strong consistency can be layered on with [Consensus and Leader Election](consensus.md), while eventually consistent designs can rely on [Fault Tolerance](fault-tolerance.md) and [Durability](durability.md).

--- a/hugo/content/docs/communication.md
+++ b/hugo/content/docs/communication.md
@@ -5,7 +5,7 @@ title: Communication
 # How actors communicate with each other
 
 {{< note >}}
-This repository provides supplemental examples for the blog article [[Golang] Protoactor-go 101: How actors communicate with each other](https://blog.oklahome.net/2018/09/protoactor-go-messaging-protocol.html), covering all message-passing methods for the various actors provided by protoactor-go.
+This repository provides supplemental examples for the blog article [[Golang] Protoactor-go 101: How actors communicate with each other](https://blog.oklahome.net/2018/09/protoactor-go-messaging-protocol.html), covering all message-passing methods for the various actors provided by protoactor-go. For higher-level guidance see [Message Patterns](message-patterns.md) and the [Ask Pattern](ask-pattern.md).
 {{</ note >}}
 
 <img src="https://raw.githubusercontent.com/oklahomer/protoactor-go-sender-example/master/docs/components.png"

--- a/hugo/content/docs/consensus.md
+++ b/hugo/content/docs/consensus.md
@@ -6,7 +6,7 @@ tags: [protoactor, docs]
 ---
 # Consensus and Leader Election
 
-Consensus algorithms coordinate state across nodes so that the cluster agrees on a single value. They are essential when strong consistency or coordination is required.
+Consensus algorithms coordinate state across nodes so that the cluster agrees on a single value. They are essential when strong consistency or coordination is required, as described by the [CAP Theorem](cap-theorem.md) and the trade‑offs in [Consistency Models](consistency-models.md).
 
 ## Why Consensus?
 Failures and partitions can create multiple conflicting updates. Protocols like Raft or Paxos elect a leader and replicate a log to keep nodes in sync.

--- a/hugo/content/docs/consistency-models.md
+++ b/hugo/content/docs/consistency-models.md
@@ -6,15 +6,15 @@ tags: [protoactor, docs]
 ---
 # Consistency Models
 
-Distributed systems must balance consistency with availability and latency. Proto.Actor leaves those trade‑offs to application design so you can choose a model that fits your needs.
+Distributed systems must balance consistency with availability and latency. These choices are often framed by the [CAP Theorem](cap-theorem.md). Proto.Actor leaves those trade‑offs to application design so you can choose a model that fits your needs.
 
 ## Strong Consistency
 
-A strongly consistent system ensures that every read sees the latest write. Achieving this typically requires coordination or consensus which adds latency and reduces availability. Use strong consistency when correctness outweighs availability, e.g. critical financial transactions.
+A strongly consistent system ensures that every read sees the latest write. Achieving this typically requires coordination or [consensus](consensus.md) which adds latency and reduces availability. Use strong consistency when correctness outweighs availability, e.g. critical financial transactions.
 
 ## Eventual Consistency
 
-Eventual consistency allows replicas to diverge temporarily but guarantees they converge when messages are delivered. Proto.Actor's at‑most‑once messaging and location transparency work well with eventually consistent designs such as CRDTs or event sourcing because actors can replay or reconcile state after reconnection.
+Eventual consistency allows replicas to diverge temporarily but guarantees they converge when messages are delivered. Proto.Actor's at‑most‑once messaging and location transparency work well with eventually consistent designs such as CRDTs or event sourcing because actors can replay or reconcile state after reconnection. Techniques like [Fault Tolerance](fault-tolerance.md) and [Durability](durability.md) help manage the trade‑offs.
 
 ## Causal Consistency
 

--- a/hugo/content/docs/durability.md
+++ b/hugo/content/docs/durability.md
@@ -262,7 +262,7 @@ to arrive either. An ACK-RETRY protocol with business-level acknowledgements is
 supported by [[At least once delivery]] of the Proto.Actor Persistence module. Duplicates can be
 detected by tracking the identifiers of messages sent via [[At least once delivery]].
 Another way of implementing the third part would be to make processing the messages
-idempotent on the level of the business logic.
+[idempotent](idempotency.md) on the level of the business logic.
 
 Another example of implementing all three requirements is shown at
 :ref:`reliable-proxy` (which is now superseded by [[At least once delivery]]).

--- a/hugo/content/docs/envelope-pattern.md
+++ b/hugo/content/docs/envelope-pattern.md
@@ -15,7 +15,7 @@ Besides the trivial use case of writing to persistent storage, sending messages 
 
 
 #### Requires:
-* Idempotency, message deduplication in actor (can be done using `Props.WithClusterRequestDeduplication(deduplicationWindow)`, where `deduplicationWindow` is an optional field and is of `TimeSpan` type)
+* [Idempotency in Messaging](idempotency.md) and message deduplication in actor (can be done using `Props.WithClusterRequestDeduplication(deduplicationWindow)`, where `deduplicationWindow` is an optional field and is of `TimeSpan` type)
 
 #### Pros:
 * High throughput processing

--- a/hugo/content/docs/idempotency.md
+++ b/hugo/content/docs/idempotency.md
@@ -1,0 +1,25 @@
+---
+title: "Idempotency in Messaging"
+date: 2025-08-09T00:00:00Z
+draft: false
+tags: [protoactor, docs]
+---
+# Idempotency in Messaging
+
+In distributed systems messages may be delivered more than once. Idempotent handlers ensure that processing a message multiple times yields the same result, making retries safe.
+
+## Techniques
+
+- Track processed message identifiers and discard duplicates
+- Use database constraints or compare-and-swap operations
+- Design operations so that applying them twice has no additional effect
+
+## Proto.Actor Support
+
+Proto.Actor offers tools to help implement idempotency:
+
+- `Props.WithClusterRequestDeduplication` keeps a cache of recent requests to drop duplicates
+- [Envelope Pattern](envelope-pattern.md) groups messages so you can acknowledge a batch after state is persisted
+- [Durability](durability.md) explains delivery guarantees and why duplicate messages appear
+
+Combine these techniques with [Reentrancy](reenter.md) for non-blocking retries.

--- a/hugo/content/docs/message-patterns.md
+++ b/hugo/content/docs/message-patterns.md
@@ -1,4 +1,19 @@
+---
+title: "Messaging Patterns"
+date: 2025-08-09T00:00:00Z
+draft: false
+tags: [protoactor, docs]
+---
 # Messaging Patterns
+
+Actors communicate by exchanging messages. Proto.Actor supports several common patterns that build on this simple foundation.
+
+- **Send** – fire and forget, the sender does not expect a reply.
+- **[Ask Pattern](ask-pattern.md)** – request–response using `Request` or `RequestAsync`.
+- **[Envelope Pattern](envelope-pattern.md)** – batch multiple messages and acknowledge them as a unit.
+- **Routing** – use [Routers](routers.md) to distribute work across actors or forward messages.
+
+The diagram below summarizes how messages can be routed and queued.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary
- cross-link CAP theorem, consistency models, and consensus pages
- add docs for ask pattern and idempotency; enhance message patterns
- update docs index with missing concepts like fault tolerance and communication

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689742930a488328af9b77c401c3e27b