### PR TITLE
docs: expand Ask pattern and add diagrams

### DIFF
--- a/hugo/content/docs/ask-pattern.md
+++ b/hugo/content/docs/ask-pattern.md
@@ -8,12 +8,38 @@ tags: [protoactor, docs]
 
 The ask pattern provides request–response semantics between actors. An actor sends a message and waits for a reply, typically by using a future or awaiting a `Task`.
 
+## Basic Flow
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Target
+    Caller->>Target: Request
+    Target-->>Caller: Response
+```
+
 In Proto.Actor you can use `Context.Request` when the sender expects the recipient to know who sent the message. For an awaitable response, `Context.RequestAsync<T>` or `PID.RequestAsync<T>` returns a `Task<T>` that completes when the reply arrives.
 
 ```csharp
+// ask a target actor for a reply
 var response = await pid.RequestAsync<MyReply>(new MyRequest());
 ```
 
-Because the actor thread is released while waiting, combine the ask pattern with [Reentrancy](reenter.md) to avoid blocking the actor. For fire‑and‑forget messaging, prefer `Context.Send`.
+## When to Use
+- Querying another actor for state or service results.
+- Bridging between actor code and external await-based APIs.
+- Providing back-pressure by limiting concurrent pending requests.
+
+## Reentrancy and Ask
+Waiting on `RequestAsync` inside an actor's receive method suspends message processing until the task completes. Combine the ask pattern with [Reentrancy](reenter.md) (`RequestReenter` or `ReenterAfter`) to keep the actor responsive. Without reentrancy, the actor cannot handle other messages and may cause a deadlock.
+
+## Deadlock Example
+```mermaid
+flowchart LR;
+
+    A[Actor A] --ask--> B[Actor B];
+    B --ask--> A;
+
+```
+If Actor A awaits a reply from Actor B while B simultaneously awaits a reply from A, neither actor can proceed. Reentrancy or redesigning the communication flow breaks the cycle.
 
 See [Actor Communication](communication.md) for an overview of messaging APIs and [PID](pid.md) for additional request options.

--- a/hugo/content/docs/circuit-breaker.md
+++ b/hugo/content/docs/circuit-breaker.md
@@ -8,11 +8,29 @@ tags: [protoactor, docs]
 
 A circuit breaker prevents a failing dependency from overwhelming the system. When error rates exceed a threshold the breaker "opens" and short‑circuits requests until the dependency recovers.
 
+## State Transitions
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> Open: failures > threshold
+    Open --> HalfOpen: timeout expires
+    HalfOpen --> Closed: trial success
+    HalfOpen --> Open: failure
+```
+
 ## Why Use It?
 Remote calls may hang or fail rapidly. Without protection, actors waiting on those calls can pile up and consume resources.
 
 ## Implementing in Proto.Actor
 Wrap outbound requests in a circuit breaker component. On failure, record the error and temporarily reject new requests. After a cool‑down period allow a limited number of trial requests; if they succeed the breaker closes.
+
+## Interaction
+```mermaid
+flowchart LR;
+    Actor[Calling Actor] --> Breaker[Circuit Breaker];
+    Breaker -->|closed| Service[Dependency];
+    Breaker -.open.-> Actor;
+```
 
 ## Example
 ```cs

--- a/hugo/content/docs/deadlocks.md
+++ b/hugo/content/docs/deadlocks.md
@@ -11,7 +11,12 @@ It's entirely possible to create a deadlock by awaiting actor-to-actor or actor-
 
 One situation where a deadlock may occur is when actor initiates requests to itself and awaits the result. In this case the request message cannot be processed, since the processing is blocked by awaiting.
 
-![Actor deadlock](images/actor-deadlock.png)
+```mermaid
+flowchart LR;
+
+    A[Actor] --request and await--> A;
+
+```
 
 Requesting to self in order to get some result back is rarely a good idea. In most cases accessing the actor's state directly is a better solution.
 


### PR DESCRIPTION
## Summary
- enrich Ask pattern docs with flow and deadlock diagrams and reentrancy guidance
- replace deadlock image with mermaid diagram for actor-to-self deadlock
- add circuit breaker state and interaction diagrams

## Testing
- `hugo version`
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_689755b311008328989e31b32c41ba45