### PR TITLE
docs: add mermaid diagrams

### DIFF
--- a/hugo/content/docs/actors-vs-queues.md
+++ b/hugo/content/docs/actors-vs-queues.md
@@ -9,6 +9,19 @@ tags: [actors, queues, logs]
 
 Actors excel at managing in-memory state and orchestrating concurrent work. Their mailboxes are ephemeral and rely on best-effort delivery. If a process crashes, in-flight messages may be lost. For workflows that demand durable delivery, ordering or exactly-once processing, a dedicated queue or log is the safer option.
 
+The diagram below contrasts direct actor messaging with using a persistent queue or log.
+
+```mermaid
+graph LR
+    producer((Producer<br>Actor))
+    consumer((Consumer<br>Actor))
+    queue[(Queue/Log)]
+    class queue yellow
+
+    producer --> consumer
+    producer --- queue --> consumer
+```
+
 ## Real-time vs durable messaging
 
 Actors pass messages directly in memory and can react in microseconds. This makes them ideal for real-time workloads such as multiplayer games or IoT device coordination where even small delays are unacceptable. Queues and logs persist to disk and replicate data, adding milliseconds of latency. They are "realtime-ish": great for reliability, but they cannot meet ultra low-latency requirements.

--- a/hugo/content/docs/hello-world.md
+++ b/hugo/content/docs/hello-world.md
@@ -137,6 +137,20 @@ pid := system.Root.Spawn(props)
 
 Finally, let's send a `Hello` message to our `HelloWorldActor`:
 
+```mermaid
+graph LR
+    sender(Main)
+    class sender green
+    pid(PID)
+    class pid light-blue
+    msg(Hello)
+    class msg message
+    receiver((HelloWorld<br>Actor))
+
+    sender --> msg
+    msg --- pid --> receiver
+```
+
 #### .NET
 
 ```csharp

--- a/hugo/content/docs/location-transparency.md
+++ b/hugo/content/docs/location-transparency.md
@@ -23,7 +23,22 @@ No matter if they are close or far away.
 ##### Using a PID to communicate with a remote actor:
 ![Remote Actor](images/actor-remote.png)
 
+The same PID can route messages to both local and remote actors:
 
+```mermaid
+graph LR
+    pid(PID)
+    class pid light-blue
+    network(Network)
+    class network message
+
+    sender((Actor))
+    local((Actor))
+    remote((Actor))
+
+    sender --- pid --> local
+    sender --- pid --> network --> remote
+```
 
 ## Ways in which Transparency is Broken
 


### PR DESCRIPTION
## Summary
- illustrate direct actor messaging versus queue/log workflows
- show how a single PID can reach local or remote actors
- depict message flow in the Hello World example

## Testing
- `hugo --minify`
- `npx markdownlint hugo/content/docs/actors-vs-queues.md hugo/content/docs/location-transparency.md hugo/content/docs/hello-world.md` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_689845daf7388328995123d0ae6b040e