### PR TITLE
docs: add Go grains getting started guide

### DIFF
--- a/hugo/content/docs/_index.md
+++ b/hugo/content/docs/_index.md
@@ -12,6 +12,7 @@ tags: [protoactor, docs]
 - [Hello World](hello-world)
 - [Getting Started](getting-started)
 - [Getting Started With Grains / Virtual Actors (.NET)](cluster/getting-started-net.md)
+- [Getting Started With Grains / Virtual Actors (Go)](cluster/getting-started-go.md)
 - [Deploy to Kubernetes](cluster/getting-started-kubernetes.md)
 
 ## Introduction

--- a/hugo/content/docs/cluster.md
+++ b/hugo/content/docs/cluster.md
@@ -202,7 +202,8 @@ Here are some examples of cluster identities:
 
 If you're new to the concept of virtual actors / grains, it's highly recommended that you take a look at a tutorial:
 
-[Getting Started With Grains / Virtual Actors (.NET)](cluster/getting-started-net.md)
+- [Getting Started With Grains / Virtual Actors (.NET)](cluster/getting-started-net.md)
+- [Getting Started With Grains / Virtual Actors (Go)](cluster/getting-started-go.md)
 
 ## Proto.Cluster components
 

--- a/hugo/content/docs/cluster/getting-started-kubernetes.md
+++ b/hugo/content/docs/cluster/getting-started-kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes deployment
 
-This is the continuation of the [Getting Started With Grains tutorial](getting-started-net.md). For now, the tutorial showed how to run multiple members locally using Consul.
+This is the continuation of the [Getting Started With Grains tutorial for .NET](getting-started-net.md). If you're using Go, start with the [Getting Started With Grains / Virtual Actors (Go)](getting-started-go.md) guide. For now, the tutorial showed how to run multiple members locally using Consul.
 The same setup might be also suitable for some deployment cases, but since modern applications are more often deployed in Kubernetes, it is better to select dedicated provider for it.
 
 [Kubernetes provider](kubernetes-provider-net.md) is another implementation of `IClusterProvider` interface, the same as [Consul provider](cluster/consul-net.md). For more information you can check [Cluster providers section](cluster-providers-net.md).


### PR DESCRIPTION
## Summary
- add Go version of getting-started grains tutorial
- link new guide from index and cluster docs
- reference Go tutorial in Kubernetes deployment guide

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68984692468483289c08a8da4887ce77