### PR TITLE
docs: promote tell over ask pattern

### DIFF
--- a/hugo/content/docs/ask-pattern.md
+++ b/hugo/content/docs/ask-pattern.md
@@ -29,16 +29,52 @@ var response = await pid.RequestAsync<MyReply>(new MyRequest());
 - Bridging between actor code and external await-based APIs.
 - Providing back-pressure by limiting concurrent pending requests.
 
+## Tell, Don't Ask
+In an asynchronous system it's often better to emit events about your state
+rather than having others ask for it. By telling peers about changes, actors
+stay loosely coupled and can react when they are ready.
+
+```mermaid
+flowchart LR
+    producer((Producer)) -- emits --> evt(StateChanged)
+    evt --> consumer((Consumer))
+    class evt message green
+```
+
+```csharp
+public class Counter : IActor
+{
+    private int _value;
+
+    public Task ReceiveAsync(IContext context)
+    {
+        switch (context.Message)
+        {
+            case Increment _:
+                _value++;
+                // tell others instead of expecting them to ask
+                EventStream.Instance.Publish(new CountChanged(_value));
+                break;
+        }
+        return Task.CompletedTask;
+    }
+}
+```
+
+Listeners subscribe to the emitted events and can maintain local state without
+performing additional request–response roundtrips.
+
 ## Reentrancy and Ask
 Waiting on `RequestAsync` inside an actor's receive method suspends message processing until the task completes. Combine the ask pattern with [Reentrancy](reenter.md) (`RequestReenter` or `ReenterAfter`) to keep the actor responsive. Without reentrancy, the actor cannot handle other messages and may cause a deadlock.
 
 ## Deadlock Example
 ```mermaid
-flowchart LR;
-
-    A[Actor A] --ask--> B[Actor B];
-    B --ask--> A;
-
+flowchart LR
+    A((Actor A)) --> req1(Request)
+    req1 --> B((Actor B))
+    B --> req2(Request)
+    req2 --> A
+    class req1,req2 message yellow
 ```
 If Actor A awaits a reply from Actor B while B simultaneously awaits a reply from A, neither actor can proceed. Reentrancy or redesigning the communication flow breaks the cycle.
 


### PR DESCRIPTION
## Summary
- explain why emitting events is often preferable to request-response asks
- illustrate event-driven communication with code and Mermaid diagrams
- clarify deadlock scenario with actor and message nodes

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_689878380f288328b961aaa449423b63