### PR TITLE
docs: add diagrams for context and receive timeout

### DIFF
--- a/hugo/content/docs/context.md
+++ b/hugo/content/docs/context.md
@@ -9,6 +9,38 @@ tags: [protoactor, docs]
 
 Proto.Actor provides two forms of Context, a `RootContext` and an `ActorContext`. These contexts are composed of various functionality provided by distinct facets. Both types of context implement `Spawner`, `Stopper`, `Info` and `Sender` facets, while the `ActorContext` implements additional facets.
 
+```mermaid
+graph LR
+    root[RootContext]
+    actor[ActorContext]
+
+    subgraph "Shared Facets"
+        spawner[Spawner]
+        stopper[Stopper]
+        info[Info]
+        sender[Sender]
+    end
+
+    subgraph "ActorContext Only"
+        receiver[Receiver]
+        invoker[Invoker]
+        supervisor[Supervisor]
+    end
+
+    root --> spawner
+    root --> stopper
+    root --> info
+    root --> sender
+
+    actor --> spawner
+    actor --> stopper
+    actor --> info
+    actor --> sender
+    actor --> receiver
+    actor --> invoker
+    actor --> supervisor
+```
+
 ## Root Context Facets
 
   - [Spawner](#spawner)

--- a/hugo/content/docs/receive-timeout.md
+++ b/hugo/content/docs/receive-timeout.md
@@ -7,6 +7,18 @@ title: Receive timeout
 
 The `Context.SetReceiveTimeout` defines the inactivity timeout after which the sending of a `ReceiveTimeout` message is triggered. When specified, the Receive function should be able to handle an `ReceiveTimeout` message.
 
+```mermaid
+sequenceDiagram
+    participant S as Sender
+    participant A as Actor
+    participant T as Timer
+
+    A->>T: SetReceiveTimeout
+    S->>A: Message
+    A->>T: Reset timer
+    T-->>A: ReceiveTimeout
+```
+
 {{< note >}}
 Please note that the receive timeout might fire and enqueue the ReceiveTimeout message right after another message was enqueued; hence it is not guaranteed that upon reception of the receive timeout there must have been an idle period beforehand as configured via this method.
 {{</ note >}}


### PR DESCRIPTION
## Summary
- illustrate context facets for RootContext and ActorContext
- show receive timeout sequence for actor inactivity

## Testing
- `hugo`

------
https://chatgpt.com/codex/tasks/task_e_68987f3c23d48328aa93ecbbe615a35a