### PR TITLE
Refine homepage messaging

### DIFF
--- a/hugo/content/_index.html
+++ b/hugo/content/_index.html
@@ -21,8 +21,7 @@ layout: empty
           data-inject-svg />
         <h4>Cloud Native</h4>
         <p>
-          Built on cloud native technologies.
-          Taking advantage of proven stability and performance.
+          Built for the cloud on a foundation of proven technology that delivers rock-solid stability and performance.
         </p>
       </div>
     </div>
@@ -31,7 +30,7 @@ layout: empty
         <img class="icon icon-lg bg-white" src="/assets/img/icons/theme/files/share.svg" alt="Icon" data-inject-svg />
         <h4>Simple Concurrency & Distribution</h4>
         <p>
-          Asynchronous and Distributed by design. High-level abstractions like Actors and Virtual Grains.
+          Designed for asynchronous, distributed workloads. Leverage high-level abstractions like actors and virtual grains without low-level plumbing.
         </p>
       </div>
     </div>
@@ -42,7 +41,7 @@ layout: empty
           data-inject-svg />
         <h4>Extreme Performance</h4>
         <p>
-          Capable of millions of messages per second cross-process communication
+          Engineered for extreme throughput, handling millions of cross-process messages per second.
         </p>
       </div>
     </div>
@@ -52,7 +51,7 @@ layout: empty
           data-inject-svg />
         <h4>Resilient by Design</h4>
         <p>
-          Write systems that self-heal using supervisor hierarchies.
+          Build self-healing systems with proven supervisor hierarchies.
         </p>
       </div>
     </div>
@@ -70,15 +69,15 @@ layout: empty
           <!-- Calendly link widget begin -->
           <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">
           <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
-          <a href="" class="btn btn-primary"
-            onclick="Calendly.initPopupWidget({url: 'https://calendly.com/asynkron?hide_landing_page_details=0&hide_gdpr_banner=1'});return false;">
-            Schedule time with us on a video call</a><br><br>
+            <a href="" class="btn btn-primary"
+              onclick="Calendly.initPopupWidget({url: 'https://calendly.com/asynkron?hide_landing_page_details=0&hide_gdpr_banner=1'});return false;">
+              Schedule a video call with us</a><br><br>
           <!-- Calendly link widget end -->
         </div>
 
-        <div class="lead">Or, get in touch with our Customer Service.</div>
+        <div class="lead">Or reach out to our customer service team.</div>
         <div class="lead">
-          Simply complete the following form, and click the Submit button. We look forward to assisting you.</div>
+          Fill out the form below and we'll respond promptly.</div>
       </div>
     </div>
   </div>
@@ -164,9 +163,9 @@ layout: empty
     <div class="row align-items-center justify-content-around">
       <div class="text-center ">
 
-        <h2>
-          Sponsors and Partners
-        </h2>
+          <h2>
+            Our Sponsors and Partners
+          </h2>
 
       </div>
     </div>
@@ -206,7 +205,7 @@ layout: empty
     <div class="row align-items-center justify-content-around">
       <div class="text-center ">
         <img src="/assets/img/asynkron/protoactor-logo.png" height="120">
-        <p class="lead">Cross-platform actors for .NET and Go<br>
+        <p class="lead">Cross-platform actor framework for .NET and Go<br>
         </p>
       </div>
     </div>
@@ -217,11 +216,9 @@ layout: empty
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
           <h2 class="h1">Actor Model</h2>
-          <p class="lead">The Actor Model provides a higher level of abstraction for writing concurrent and
-            distributed
-            systems. It alleviates the developer from having to deal with explicit locking and thread
-            management, making
-            it easier to write correct concurrent and parallel systems.</p>
+          <p class="lead">The Actor Model offers a high-level abstraction for building concurrent and
+            distributed systems. It removes the need for explicit locks and thread management,
+            making it easier to write reliable parallel code.</p>
           <a href="/docs/actors"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -239,12 +236,9 @@ layout: empty
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
           <h2 class="h1">Grains / Virtual Actors</h2>
-          <p class="lead">Grain abstraction, which provides a <b>straightforward approach to building
-              distributed interactive applications</b>, without the need to learn complex programming
-            patterns
-            for
-            handling concurrency,
-            fault tolerance, and resource management.</p>
+          <p class="lead">Grains encapsulate state and behavior, letting you build interactive distributed
+            applications without mastering complex patterns for concurrency, fault tolerance, or resource
+            management.</p>
           <a href="/docs/cluster"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -257,10 +251,8 @@ layout: empty
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
           <h2 class="h1">Stream Processing</h2>
-          <p class="lead">Proto.Actor is designed to <b>optimize for locality</b>, grains can <b>gradually
-              migrate</b>
-            to cluster members from where it receives the most interactions.
-            This allows Proto.Actor to leverage in-process performance for realtime stream processing.
+          <p class="lead">Proto.Actor optimizes for locality: grains automatically migrate toward the nodes
+            that interact with them most, delivering in-process performance for real-time stream processing.
           </p>
           <a href="/docs/local-affinity"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
@@ -280,13 +272,8 @@ layout: empty
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
           <h2 class="h1">Digital Twins</h2>
-          <p class="lead">
-            A digital twin is a virtual representation that serves as the real-time digital counterpart of a
-            physical
-            object or process.
-            By leveraging Proto.Actors local affinity strategy, digital twins can react on external events
-            in
-            realtime.
+          <p class="lead">A digital twin mirrors a physical object or process. With Proto.Actor's
+            local-affinity strategy, twins stay close to their data and respond to events in real time.
           </p>
           <a href="/docs/local-affinity"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
@@ -299,10 +286,8 @@ layout: empty
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
           <h2 class="h1">Metrics and Tracing</h2>
-          <p class="lead">Observability is an essential feature for distributed systems. Every area of
-            Proto.Actor has been instrumented to allow users to extract runtime and
-            performance metrics.<br>
-            Dashboards for DataDog and Grafana are provided out of the box.
+          <p class="lead">Proto.Actor is instrumented end-to-end for observability, exposing runtime and
+            performance metrics with ready-to-use dashboards for DataDog and Grafana.
           </p>
           <a href="/docs/metrics"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>

--- a/hugo/themes/blank/layouts/partials/proto-info.html
+++ b/hugo/themes/blank/layouts/partials/proto-info.html
@@ -3,7 +3,7 @@
     <div class="row align-items-center justify-content-around">
       <div class="text-center ">
         <img src="/assets/img/asynkron/protoactor-logo.png" height="120">
-        <p class="lead">Cross-platform actors for .NET and Go<br>
+        <p class="lead">Cross-platform actor framework for .NET and Go<br>
         </p>
       </div>
     </div>
@@ -12,10 +12,10 @@
     <div class="row align-items-center justify-content-around">
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
-          <h2 class="h1">Actor Model</h2>
-          <p class="lead">The Actor Model provides a higher level of abstraction for writing concurrent and distributed
-            systems. It alleviates the developer from having to deal with explicit locking and thread management, making
-            it easier to write correct concurrent and parallel systems.</p>
+        <h2 class="h1">Actor Model</h2>
+        <p class="lead">The Actor Model offers a high-level abstraction for building concurrent and distributed
+          systems. It removes the need for explicit locks and thread management,
+          making it easier to write reliable parallel code.</p>
           <a href="/docs/actors"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -32,11 +32,10 @@
       </div>
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
-          <h2 class="h1">Grains / Virtual Actors</h2>
-          <p class="lead">Grain abstraction, which provides a <b>straightforward approach to building
-              distributed interactive applications</b>, without the need to learn complex programming patterns for
-            handling concurrency,
-            fault tolerance, and resource management.</p>
+        <h2 class="h1">Grains / Virtual Actors</h2>
+        <p class="lead">Grains encapsulate state and behavior, letting you build interactive distributed
+          applications without mastering complex patterns for concurrency, fault tolerance, or resource
+          management.</p>
           <a href="/docs/cluster"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -48,11 +47,10 @@
     <div class="row align-items-center justify-content-around">
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
-          <h2 class="h1">Stream Processing</h2>
-          <p class="lead">Proto.Actor is designed to <b>optimize for locality</b>, grains can <b>gradually migrate</b>
-            to cluster members from where it receives the most interactions.
-            This allows Proto.Actor to leverage in-process performance for realtime stream processing.
-          </p>
+        <h2 class="h1">Stream Processing</h2>
+        <p class="lead">Proto.Actor optimizes for locality: grains automatically migrate toward the nodes
+          that interact with them most, delivering in-process performance for real-time stream processing.
+        </p>
           <a href="/docs/local-affinity"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -70,12 +68,10 @@
       </div>
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
-          <h2 class="h1">Digital Twins</h2>
-          <p class="lead">
-            A digital twin is a virtual representation that serves as the real-time digital counterpart of a physical
-            object or process.
-            By leveraging Proto.Actors local affinity strategy, digital twins can react on external events in realtime.
-          </p>
+        <h2 class="h1">Digital Twins</h2>
+        <p class="lead">A digital twin mirrors a physical object or process. With Proto.Actor's local-affinity
+          strategy, twins stay close to their data and respond to events in real time.
+        </p>
           <a href="/docs/local-affinity"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>
@@ -86,12 +82,10 @@
     <div class="row align-items-center justify-content-around">
       <div class="col-md-9 col-lg-6 ">
         <div class="text-center text-lg-left">
-          <h2 class="h1">Metrics and Tracing</h2>
-          <p class="lead">Observability is an essential feature for distributed systems. Every area of
-            Proto.Actor has been instrumented to allow users to extract runtime and
-            performance metrics.<br>
-            Dashboards for DataDog and Grafana are provided out of the box.
-          </p>
+        <h2 class="h1">Metrics and Tracing</h2>
+        <p class="lead">Proto.Actor is instrumented end-to-end for observability, exposing runtime and
+          performance metrics with ready-to-use dashboards for DataDog and Grafana.
+        </p>
           <a href="/docs/metrics"> Read More <img class="icon icon-sm bg-primary"
               src="/assets/img/icons/theme/code/right-circle.svg" alt="Icon" data-inject-svg /></a></small>
         </div>


### PR DESCRIPTION
## Summary
- polish landing page copy for features, contact, and sponsor sections
- sync proto-info partial with new wording for docs

## Testing
- `hugo -s hugo`


------
https://chatgpt.com/codex/tasks/task_e_689899df90948328898efc7658546db2