### PR TITLE
Add Go examples for gRPC compression and TLS docs

### DIFF
--- a/hugo/content/docs/grpc-compression.md
+++ b/hugo/content/docs/grpc-compression.md
@@ -4,10 +4,12 @@ title: gRPC Compression
 
 # gRPC Compression
 
-Configure gRPC compression for Proto.Remote:
+Configure gRPC compression for Proto.Remote.
+
+## .NET
 
 ```csharp
-var remoteConfig = 
+var remoteConfig =
     GrpcNetRemoteConfig
     .BindTo(advertisedHost)
     .WithChannelOptions(new GrpcChannelOptions
@@ -19,5 +21,32 @@ var remoteConfig =
         }
     )
     .WithProtoMessages(ProtosReflection.Descriptor);
+
+```
+
+## Go
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/encoding/gzip"
+
+    remote "github.com/asynkron/protoactor-go/remote"
+)
+
+func main() {
+    // Register gzip and enable it for both client and server
+    _ = gzip.Name
+
+    cfg := remote.Configure("127.0.0.1", 8080,
+        remote.WithServerOptions(grpc.RPCCompressor(grpc.NewGZIPCompressor())),
+        remote.WithDialOptions(grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name))),
+    )
+
+    remote.NewRemote(actor.NewActorSystem(), cfg).Start()
+}
 
 ```

--- a/hugo/content/docs/grpc-tls.md
+++ b/hugo/content/docs/grpc-tls.md
@@ -1,0 +1,75 @@
+---
+title: gRPC TLS
+---
+
+# gRPC TLS
+
+Proto.Remote can secure communication channels using TLS certificates.
+
+## Generating a development certificate
+
+```bash
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+openssl pkcs12 -export -out localhost.pfx -inkey key.pem -in cert.pem -passout pass:password
+```
+
+## .NET
+
+Server configuration:
+
+```csharp
+var certificate = new X509Certificate2("localhost.pfx", "password");
+var remoteConfig = GrpcNetRemoteConfig.BindTo(advertisedHost) with
+{
+    UseHttps = true,
+    ConfigureKestrel = options =>
+    {
+        options.Protocols = HttpProtocols.Http2;
+        options.UseHttps(certificate);
+    }
+};
+```
+
+Client validation:
+
+```csharp
+var certificate = new X509Certificate2("localhost.pfx", "password");
+var handler = new HttpClientHandler();
+handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) =>
+    cert != null && cert.Thumbprint == certificate.Thumbprint;
+
+var remoteConfig = GrpcNetRemoteConfig.BindToLocalhost() with
+{
+    UseHttps = true,
+    ChannelOptions = new GrpcChannelOptions { HttpHandler = handler }
+};
+```
+
+## Go
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    remote "github.com/asynkron/protoactor-go/remote"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+)
+
+func main() {
+    // Load server cert and key
+    serverCreds, _ := credentials.NewServerTLSFromFile("server.crt", "server.key")
+    // Client credentials verify the server certificate
+    clientCreds, _ := credentials.NewClientTLSFromFile("server.crt", "")
+
+    cfg := remote.Configure("127.0.0.1", 8080,
+        remote.WithServerOptions(grpc.Creds(serverCreds)),
+        remote.WithDialOptions(grpc.WithTransportCredentials(clientCreds)),
+    )
+
+    remote.NewRemote(actor.NewActorSystem(), cfg).Start()
+}
+```
+
+This configuration enables encrypted gRPC streaming between Proto.Actor nodes.

--- a/hugo/content/docs/remote.md
+++ b/hugo/content/docs/remote.md
@@ -124,7 +124,71 @@ var remoteConfig =
     );
 ```
 
-You can read more about gPRC compression [here](grpc-compression.md).
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    remote "github.com/asynkron/protoactor-go/remote"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/encoding/gzip"
+)
+
+func main() {
+    _ = gzip.Name // register gzip
+
+    cfg := remote.Configure("127.0.0.1", 8080,
+        remote.WithServerOptions(grpc.RPCCompressor(grpc.NewGZIPCompressor())),
+        remote.WithDialOptions(grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name))),
+    )
+
+    remote.NewRemote(actor.NewActorSystem(), cfg).Start()
+}
+```
+
+You can read more about gRPC compression [here](grpc-compression.md).
+
+### Configure TLS
+
+Proto.Remote can also secure connections with TLS certificates.
+
+```csharp
+var certificate = new X509Certificate2("localhost.pfx", "password");
+var remoteConfig = GrpcNetRemoteConfig.BindTo(advertisedHost) with
+{
+    UseHttps = true,
+    ConfigureKestrel = options =>
+    {
+        options.Protocols = HttpProtocols.Http2;
+        options.UseHttps(certificate);
+    }
+};
+```
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    remote "github.com/asynkron/protoactor-go/remote"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials"
+)
+
+func main() {
+    serverCreds, _ := credentials.NewServerTLSFromFile("server.crt", "server.key")
+    clientCreds, _ := credentials.NewClientTLSFromFile("server.crt", "")
+
+    cfg := remote.Configure("127.0.0.1", 8080,
+        remote.WithServerOptions(grpc.Creds(serverCreds)),
+        remote.WithDialOptions(grpc.WithTransportCredentials(clientCreds)),
+    )
+
+    remote.NewRemote(actor.NewActorSystem(), cfg).Start()
+}
+```
+
+For a more complete example see [gRPC TLS](grpc-tls.md).
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- document configuring gRPC compression in Go and .NET
- add TLS setup guide with server and client examples for both runtimes
- expand remote docs with Go snippets for compression and TLS

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_689906f9806c8328ae03538c265d3136