### PR TITLE
style: theme state diagrams

### DIFF
--- a/hugo/themes/blank/layouts/partials/footer-include.html
+++ b/hugo/themes/blank/layouts/partials/footer-include.html
@@ -259,7 +259,6 @@
 
   $prefix .stateGroup text,
   $prefix .stateLabel text,
-  $prefix .edgeLabel .label text,
   $prefix .cluster-label,
   $prefix .nodeLabel {
     fill: ${textColor} !important;
@@ -267,16 +266,28 @@
     font-family: ${fontFamily};
   }
 
-  $prefix .edgeLabel .label rect,
-  $prefix .stateLabel .box {
-    fill: none !important;
+  $prefix .edgeLabel .label text,
+  $prefix .edgeLabel span {
+    fill: #333 !important;
+    color: #333 !important;
+    font-family: ${fontFamily};
+  }
+
+  $prefix .edgeLabel span {
+    background-color: #e8e8e8;
+    text-align: center;
+  }
+
+  $prefix .edgeLabel .label rect {
+    fill: #e8e8e8 !important;
     stroke: none !important;
     opacity: 1 !important;
   }
 
-  $prefix .edgeLabel .label span {
-    color: ${textColor} !important;
-    font-family: ${fontFamily};
+  $prefix .stateLabel .box {
+    fill: none !important;
+    stroke: none !important;
+    opacity: 1 !important;
   }
 
   $prefix #statediagram-barbEnd,

--- a/hugo/themes/blank/layouts/partials/footer-include.html
+++ b/hugo/themes/blank/layouts/partials/footer-include.html
@@ -46,6 +46,7 @@
   const lightBlueColor = "#00ADF8";
   const lineWidth = "4px";
   const strokeWidth = "3px";
+  const stateLineWidth = "2px";
   const strokeColor = backgroundColor;
   const commentColor = "#FFF2CC";
   const commentBorderColor = "#D6B656";
@@ -252,7 +253,7 @@
   $prefix .transition,
   $prefix .note-edge {
     stroke: ${lineColor} !important;
-    stroke-width: ${lineWidth} !important;
+    stroke-width: ${stateLineWidth} !important;
     fill: none !important;
   }
 
@@ -268,8 +269,14 @@
 
   $prefix .edgeLabel .label rect,
   $prefix .stateLabel .box {
-    fill: ${actorColor} !important;
-    opacity: 0.5;
+    fill: none !important;
+    stroke: none !important;
+    opacity: 1 !important;
+  }
+
+  $prefix .edgeLabel .label span {
+    color: ${textColor} !important;
+    font-family: ${fontFamily};
   }
 
   $prefix #statediagram-barbEnd,
@@ -291,7 +298,7 @@
   }
 
   $prefix line {
-    stroke-width: 2px !important;
+    stroke-width: ${stateLineWidth} !important;
     stroke: #a0a0a0 !important;
   }
 

--- a/hugo/themes/blank/layouts/partials/footer-include.html
+++ b/hugo/themes/blank/layouts/partials/footer-include.html
@@ -233,6 +233,63 @@
     stroke: ${lineColor} !important;
   }
 
+  /* State diagram overrides */
+  $prefix .statediagram-state rect,
+  $prefix .statediagram-state polygon,
+  $prefix .statediagram-cluster rect {
+    fill: ${blueColor} !important;
+    stroke: ${backgroundColor} !important;
+    stroke-width: ${lineWidth} !important;
+  }
+
+  $prefix .node circle.state-start,
+  $prefix .node circle.state-end,
+  $prefix .node .fork-join {
+    fill: ${lineColor} !important;
+    stroke: ${lineColor} !important;
+  }
+
+  $prefix .transition,
+  $prefix .note-edge {
+    stroke: ${lineColor} !important;
+    stroke-width: ${lineWidth} !important;
+    fill: none !important;
+  }
+
+  $prefix .stateGroup text,
+  $prefix .stateLabel text,
+  $prefix .edgeLabel .label text,
+  $prefix .cluster-label,
+  $prefix .nodeLabel {
+    fill: ${textColor} !important;
+    color: ${textColor} !important;
+    font-family: ${fontFamily};
+  }
+
+  $prefix .edgeLabel .label rect,
+  $prefix .stateLabel .box {
+    fill: ${actorColor} !important;
+    opacity: 0.5;
+  }
+
+  $prefix #statediagram-barbEnd,
+  $prefix defs #statediagram-barbEnd {
+    fill: ${lineColor} !important;
+    stroke: ${lineColor} !important;
+  }
+
+  $prefix .state-note,
+  $prefix .statediagram-note rect {
+    fill: #ffbb00;
+    stroke: none;
+  }
+
+  $prefix .state-note text,
+  $prefix .statediagram-note text,
+  $prefix .statediagram-note .nodeLabel {
+    fill: #373635;
+  }
+
   $prefix line {
     stroke-width: 2px !important;
     stroke: #a0a0a0 !important;


### PR DESCRIPTION
## Summary
- apply site color scheme to mermaid state diagrams so they match other diagrams

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6899d6308bf88328a22195fe7e6e9e62