### PR TITLE
docs: expand bootcamp2025 chapters

### DIFF
--- a/hugo/content/docs/bootcamp2025/chapter-1.md
+++ b/hugo/content/docs/bootcamp2025/chapter-1.md
@@ -1,6 +1,6 @@
-# Proto.Actor Bootcamp Tutorial Series
+# Chapter 1: Introduction to the Actor Model and Proto.Actor
 
-## Chapter 1: Introduction to the Actor Model and Proto.Actor
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
 The actor model is a conceptual model for designing concurrent, distributed systems. In the actor model, an actor is a lightweight entity that encapsulates state and behavior, and communicates exclusively by exchanging messages. Actors do not share memory; instead, they send messages to each other asynchronously. This eliminates the need for locks or manual thread management, since each actor processes one message at a time in a single-threaded manner. The actor model provides a high-level abstraction for concurrency, making it easier to build systems that are responsive, resilient, and elastic (as advocated by the Reactive Manifesto). Key benefits of using the actor model include:
 
 - Simplified Concurrency: No explicit threads or locks — actors run independently and handle messages sequentially, avoiding race conditions by design.
@@ -12,7 +12,7 @@ The actor model is a conceptual model for designing concurrent, distributed syst
 - Fault Tolerance via Supervision: Actors form hierarchies. An actor can create child actors and supervise them. If a child actor fails (e.g., throws an exception), the parent actor can handle the failure (restart the child, replace it, etc.), creating a self-healing system.
 
 In the context of Proto.Actor, these principles are applied in a modern, cross-platform framework. Proto.Actor is an open-source actor framework available in multiple languages (including .NET/C# and Go) that implements both classic actors and “virtual actors” in clusters. It provides the building blocks to create actors, send messages, and scale out your system across cores and network nodes. Proto.Actor uses proven technologies under the hood (like gRPC for networking and Protocol Buffers for serialization) instead of reinventing them.
-This means Proto.Actor integrates well with other systems and languages, allowing, for example, a Go actor to communicate with a C# actor over the network with ease.
+Because it relies on standard tooling, Proto.Actor integrates well with other systems and languages. A Go actor can talk to a C# actor over the network without any custom glue code.
 
  
 
@@ -49,3 +49,5 @@ sequenceDiagram
 
 This diagram shows that a sender actor can put multiple messages into the receiver’s mailbox quickly, but the receiver will dequeue and handle them one by one. This ensures thread-safe processing within the actor. In the next chapters, we will build on these concepts: first by exploring Proto.Actor’s core primitives for defining and using actors, then by leveraging remote communication, clustering (with virtual actors), and finally how to test actor systems using Proto.Actor’s toolkit. Each chapter includes examples in both C# and Go, plus diagrams to solidify the concepts.
 
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)

--- a/hugo/content/docs/bootcamp2025/chapter-2.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2.md
@@ -1,4 +1,6 @@
 # Chapter 2: Proto.Actor Core Primitives
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
 Now that we understand the basic actor model, let’s see how Proto.Actor implements these concepts and what core primitives it provides. We will cover how to define an actor’s behavior, how to create and start actors, how actors send and receive messages, and how the actor lifecycle and hierarchy work. We’ll illustrate with simple examples in C# and Go.
 
 ## Actors, Messages, and the Actor System
@@ -163,6 +165,18 @@ When you spawned the actor, you got a PID. The PID (Process ID) is a core primit
 
 For example, a PID might look like Pid{ Address="", Id="Actor$123" } for a local actor, or { Address="127.0.0.1:8000", Id="remoteActor" } for a remote actor on another process. PIDs are how you send messages – you don’t call methods on an actor, you send it messages via its PID. The actor’s mailbox receives the message and eventually the actor’s Receive handles it. This indirection is what enables location transparency: if the actor moves or is actually remote, you still just have a PID. The Proto.Actor infrastructure handles delivering the message to wherever the actor lives (more on this in the Remoting chapter).
 
+```mermaid
+graph LR
+    sender((Sender))
+    msg(Message)
+    class msg message
+    pid(PID)
+    class pid light-blue
+    receiver((Receiver))
+    sender --> msg
+    msg --- pid --> receiver
+```
+
  
 
 You can obtain a PID by spawning an actor (which returns it), by looking one up by name (if you spawned with a name or registered a name in a naming system), or via cluster identity (discussed in the Cluster chapter). PIDs can also be shared: you can send a PID to another actor as part of a message (e.g., send your PID so the receiver can reply directly).
@@ -205,12 +219,12 @@ This way, your system can recover from errors without bringing down the entire p
 Here’s a simple diagram of a small actor hierarchy with a parent supervising two children:
 
 ```mermaid
-flowchart TB
-    Parent([Parent Actor])
-    Child1([Child Actor 1])
-    Child2([Child Actor 2])
-    Parent --> Child1
-    Parent --> Child2
+graph TB
+    parent((Parent Actor))
+    child1((Child Actor 1))
+    child2((Child Actor 2))
+    parent --> child1
+    parent --> child2
 ```
 
 
@@ -233,3 +247,5 @@ In this hierarchy, if Child Actor 1 encounters an error, the Parent can decide w
 - Parent/Child and Supervision – actors form a tree; parents supervise children for errors.
 
 With these basics, you can already build concurrent applications that make use of multiple actors communicating in-process. In the next chapter, we will extend this to distributed scenarios. Proto.Actor’s Remoting allows actors in different processes or machines to send messages to each other as easily as if they were local. We’ll explore how to configure and use Proto.Actor’s remote capabilities.
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)

--- a/hugo/content/docs/bootcamp2025/chapter-3.md
+++ b/hugo/content/docs/bootcamp2025/chapter-3.md
@@ -1,4 +1,6 @@
 # Chapter 3: Remoting with Proto.Actor (Proto.Remote)
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
 Thus far, our actors have all been within a single process. One of the powerful features of Proto.Actor is that it supports location transparency not just in theory but in practice: you can have actors running on different machines (or processes) communicate with each other. Proto.Actor’s Remoting module (often referred to as Proto.Remote) provides the networking layer to send messages between actor systems over the network (using gRPC under the hood). In this chapter, we’ll cover how to set up remoting, how remote actors are addressed, and a simple example of sending messages between two processes (in C# and Go).
 
 ## Why Remoting?
@@ -187,3 +189,5 @@ sequenceDiagram
 In this diagram, Actor A sends a message to Actor B’s PID. The Proto.Remote system on Node1 packages the message and sends it over the network to Node2. Node2’s remote system delivers it to Actor B. If Actor B calls Respond (or otherwise sends a message back to the original sender), the process reverses, delivering the reply to Actor A. The developer did not have to explicitly manage sockets or endpoints beyond the initial configuration – Proto.Actor’s remoting took care of it.
 
 With Proto.Remote, you can build distributed applications where each service or component runs in its own process but still interacts through actors. However, remoting requires that you manage the node membership (i.e., knowing addresses of nodes and starting them manually). For dynamic clusters with many nodes joining/leaving and virtual actor activation, Proto.Actor offers the Cluster abstraction, which we cover next.
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)

--- a/hugo/content/docs/bootcamp2025/chapter-4.md
+++ b/hugo/content/docs/bootcamp2025/chapter-4.md
@@ -1,4 +1,6 @@
 # Chapter 4: Building Distributed Solutions with Proto.Cluster (Virtual Actors)
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
 While Proto.Remote allows point-to-point communication between known nodes, Proto.Cluster builds on top of it to provide a higher-level abstraction for distributed systems: clusters of virtual actors. In Proto.Cluster, actors can be addressed by a logical identity (like “user/123”) rather than a physical PID. The cluster takes care of finding or activating an actor with that identity on some node, and routing messages to it. This greatly simplifies building scalable systems, as you do not need to manually track where each actor lives or whether it’s running – the cluster does it for you. In this chapter, we’ll explain key concepts of Proto.Cluster (cluster identities, kinds, membership, etc.), how virtual actors (grains) work, and how to configure and use a Proto.Actor cluster in C# and Go.
 
 ## Why Use a Cluster?
@@ -220,3 +222,5 @@ If you have a dynamic environment (microservices or need to scale out and in, wi
 Proto.Cluster’s virtual actors simplify the developer’s mental model: you pretend every user or entity has a persistent actor. The system ensures that is “virtually” true, activating them on demand. This can greatly simplify certain classes of applications like games, IoT systems (sensors as actors), and stateful web services.
 
 In the next (final) chapter, we will discuss how to test actor systems built with Proto.Actor. Testing concurrent and distributed code can be challenging, but Proto.Actor provides a TestKit and other tools to make writing tests for actors easier. We’ll look at examples of using Proto.TestKit for unit testing actor behavior.
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)

--- a/hugo/content/docs/bootcamp2025/chapter-5.md
+++ b/hugo/content/docs/bootcamp2025/chapter-5.md
@@ -1,4 +1,6 @@
 # Chapter 5: Testing Proto.Actor Systems with Proto.TestKit
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
 Testing is a crucial part of developing reliable systems. Actor-based systems introduce concurrency, which can make testing tricky if you try to do it with traditional approaches (like expecting results immediately, or trying to synchronize threads manually). Proto.Actor provides the Proto.TestKit module (for .NET and Go) to assist in writing tests for actors. In this chapter, we’ll cover how to use test kit features such as test probes to capture messages, how to simulate timings, and general strategies for testing actors, both in isolation and as part of a system.
 
 ## Challenges in Testing Actors
@@ -27,6 +29,15 @@ Suppose we have a simple actor that replies “pong” when it receives “ping�
 
 - Sending "ping" yields a "pong" response.
 - The actor doesn’t send any unexpected messages.
+
+```mermaid
+sequenceDiagram
+    participant Probe as TestProbe
+    participant Actor as PingActor
+    Probe->>Actor: ping
+    Actor-->>Probe: pong
+    Probe->>Probe: assert reply
+```
 
 ### C# Test using TestProbe:
 ```csharp
@@ -158,3 +169,5 @@ Testing actor-based systems can be made systematic with these tools: TestProbe t
 With Proto.Actor, since everything is message-driven, most tests boil down to “given this input message (and maybe some preceding messages), the actor should send/output this other message or produce that effect.” The testkit helps capture those outputs for verification.
 
 This concludes the Proto.Actor Bootcamp. We started from the foundational concepts of the actor model, explored Proto.Actor’s core API for building actors in C# and Go, then extended to remote communication and cluster-based virtual actors, and finally saw how to test actor systems effectively. With these tutorials, you should be able to create your own concurrent, distributed applications using Proto.Actor, step by step: first get comfortable with actors and messages, then scale out with remoting or clustering, and always validate your actor behavior with thorough tests. Happy acting!
+
+**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)


### PR DESCRIPTION
## Summary
- add chapter navigation to every bootcamp2025 page
- clarify introductory text and cross-language interoperability
- illustrate actor messaging and testing with new mermaid diagrams

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68ab15be11e88328b91f5c5fd840b4c8