### PR TITLE
Expand bootcamp core docs with feature pages

### DIFF
--- a/hugo/content/docs/bootcamp2025/chapter-2/_index.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/_index.md
@@ -1,8 +1,17 @@
 # Chapter 2: Proto.Actor Core Primitives
 
-**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
 
 Now that we understand the basic actor model, let’s see how Proto.Actor implements these concepts and what core primitives it provides. We will cover how to define an actor’s behavior, how to create and start actors, how actors send and receive messages, and how the actor lifecycle and hierarchy work. We’ll illustrate with simple examples in C# and Go.
+
+## Additional Core Topics
+
+- [Supervision](supervision/)
+- [PIDs](pids/)
+- [Metrics](metrics/)
+- [Extensions](extensions/)
+- [Dependency Injection](dependency-injection/)
+- [Spawning](spawning/)
 
 ## Actors, Messages, and the Actor System
 
@@ -249,4 +258,4 @@ In this hierarchy, if Child Actor 1 encounters an error, the Parent can decide w
 
 With these basics, you can already build concurrent applications that make use of multiple actors communicating in-process. In the next chapter, we will extend this to distributed scenarios. Proto.Actor’s Remoting allows actors in different processes or machines to send messages to each other as easily as if they were local. We’ll explore how to configure and use Proto.Actor’s remote capabilities.
 
-**Chapters:** [1](chapter-1/) | [2](chapter-2/) | [3](chapter-3/) | [4](chapter-4/) | [5](chapter-5/)
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)

--- a/hugo/content/docs/bootcamp2025/chapter-2/dependency-injection.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/dependency-injection.md
@@ -1,0 +1,58 @@
+# Chapter 2: Dependency Injection
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+Actors often need services such as logging or databases. Dependency Injection (DI) can create actors with those dependencies while keeping code testable.
+
+## Using DI in C#
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Proto;
+
+var services = new ServiceCollection();
+services.AddSingleton<IMyService, MyService>();
+var provider = services.BuildServiceProvider();
+
+var system = new ActorSystem();
+var props = Props.FromProducer(() => new MyActor(provider.GetRequiredService<IMyService>()));
+var pid = system.Root.Spawn(props);
+```
+
+## Using DI in Go
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    "github.com/asynkron/protoactor-go/di"
+)
+
+type myService struct{}
+
+type myActor struct{ svc *myService }
+
+func (a *myActor) Receive(ctx actor.Context) {}
+
+func main() {
+    builder := di.New()
+    builder.Register(func() *myService { return &myService{} })
+    props := di.PropsFromFunc(builder, func(svc *myService) actor.Actor { return &myActor{svc: svc} })
+    system := actor.NewActorSystem()
+    pid := system.Root.Spawn(props)
+    _ = pid
+}
+```
+
+## DI Diagram
+
+```mermaid
+graph LR
+    container[[DI Container]]
+    actor((Actor))
+    class actor green
+    container --> actor
+```

--- a/hugo/content/docs/bootcamp2025/chapter-2/extensions.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/extensions.md
@@ -1,0 +1,54 @@
+# Chapter 2: Extensions
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+Extensions add optional capabilities to the `ActorSystem` without changing its core. Examples include metrics exporters, cluster providers, or dependency injection helpers.
+
+## Creating an Extension
+
+C# example registering a simple extension:
+
+```csharp
+using Proto;
+
+public class MyExtensionId : ExtensionId<MyExtension>
+{
+    public override MyExtension CreateExtension(ActorSystem system) => new MyExtension();
+}
+
+public class MyExtension : IExtension { }
+
+var system = new ActorSystem();
+system.Extensions.Register(new MyExtensionId());
+```
+
+Go example:
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+)
+
+type myExtension struct{}
+
+func (*myExtension) Started(*actor.ActorSystem) {}
+
+func main() {
+    system := actor.NewActorSystem()
+    system.Extensions.Register(&myExtension{})
+}
+```
+
+## Extension Diagram
+
+```mermaid
+graph LR
+    system[[ActorSystem]]
+    ext[[Extension]]
+    class ext yellow
+    system --- ext
+```

--- a/hugo/content/docs/bootcamp2025/chapter-2/metrics.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/metrics.md
@@ -1,0 +1,49 @@
+# Chapter 2: Metrics
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+Proto.Actor can publish runtime metrics such as mailbox length, message throughput, or actor restarts. Metrics are exposed through extensions like Prometheus exporters.
+
+## Enabling Metrics
+
+C# example using the Prometheus extension:
+
+```csharp
+using Proto;
+using Proto.Metrics;
+
+var system = new ActorSystem();
+// Enable default metrics and export them via Prometheus
+Metrics.StartCollectors();
+var pid = system.Root.Spawn(Props.FromProducer(() => new MyActor()));
+```
+
+In Go:
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+    prom "github.com/asynkron/protoactor-go/metrics/prometheus"
+)
+
+func main() {
+    system := actor.NewActorSystem()
+    prom.StartCollectors(system) // start Prometheus collectors
+    pid := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return &myActor{} }))
+    _ = pid
+}
+```
+
+## Metrics Diagram
+
+```mermaid
+graph LR
+    actor((Actor))
+    metrics[[Metrics]]
+    class metrics green
+    actor --> metrics
+```

--- a/hugo/content/docs/bootcamp2025/chapter-2/pids.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/pids.md
@@ -1,0 +1,68 @@
+# Chapter 2: PIDs
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+A `PID` (Process ID) is the address of an actor. It contains the actor's unique ID and the address of the node hosting it. All communication with an actor goes through its PID.
+
+## Using PIDs
+
+In C#, spawning an actor returns its PID:
+
+```csharp
+using Proto;
+
+public class EchoActor : IActor
+{
+    public Task ReceiveAsync(IContext ctx)
+    {
+        // Respond with the same message
+        if (ctx.Message is string text)
+        {
+            ctx.Respond($"Echo: {text}");
+        }
+        return Task.CompletedTask;
+    }
+}
+
+var system = new ActorSystem();
+var pid = system.Root.Spawn(Props.FromProducer(() => new EchoActor()));
+system.Root.Request(pid, "hello", pid); // send a message using the PID
+```
+
+In Go, a PID is returned similarly:
+
+```go
+package main
+
+import (
+    "github.com/asynkron/protoactor-go/actor"
+)
+
+type echoActor struct{}
+
+func (e *echoActor) Receive(ctx actor.Context) {
+    switch msg := ctx.Message().(type) {
+    case string:
+        ctx.Respond("Echo: " + msg)
+    }
+}
+
+func main() {
+    system := actor.NewActorSystem()
+    pid := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return &echoActor{} }))
+    system.Root.Request(pid, "hello", pid)
+}
+```
+
+## PID Diagram
+
+```mermaid
+graph LR
+    sender((Sender))
+    pid(PID)
+    class pid light-blue
+    receiver((Receiver))
+    sender --> pid --> receiver
+```

--- a/hugo/content/docs/bootcamp2025/chapter-2/spawning.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/spawning.md
@@ -1,0 +1,36 @@
+# Chapter 2: Spawning Actors
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+Spawning creates new actors. Actors can spawn children or spawn named actors so others can find them.
+
+## Spawning Children
+
+```csharp
+var childPid = ctx.Spawn(Props.FromProducer(() => new ChildActor()));
+```
+
+```go
+childPid := ctx.Spawn(actor.PropsFromProducer(func() actor.Actor { return &childActor{} }))
+```
+
+## Named Actors
+
+```csharp
+var pid = system.Root.SpawnNamed(props, "worker1");
+```
+
+```go
+pid := system.Root.SpawnNamed(props, "worker1")
+```
+
+## Spawning Diagram
+
+```mermaid
+graph TB
+    parent((Parent))
+    child((Child))
+    parent --> child
+```

--- a/hugo/content/docs/bootcamp2025/chapter-2/supervision.md
+++ b/hugo/content/docs/bootcamp2025/chapter-2/supervision.md
@@ -1,0 +1,85 @@
+# Chapter 2: Supervision
+
+**Chapters:** [1](../chapter-1/) | [2](../chapter-2/) | [3](../chapter-3/) | [4](../chapter-4/) | [5](../chapter-5/)
+
+[Back to Chapter 2](../)
+
+Supervision links parents and children into a hierarchy. If a child fails, the parent decides how to handle the failure: restart the child, stop it, or escalate the error.
+
+## Basic Supervision
+
+C# example showing a parent supervising a child:
+
+```csharp
+using Proto;
+using System;
+
+public class ChildActor : IActor
+{
+    public Task ReceiveAsync(IContext ctx)
+    {
+        if (ctx.Message is string msg && msg == "fail")
+        {
+            throw new Exception("boom");
+        }
+        return Task.CompletedTask;
+    }
+}
+
+public class ParentActor : IActor
+{
+    public Task ReceiveAsync(IContext ctx)
+    {
+        switch (ctx.Message)
+        {
+            case Started:
+                // spawn a child when parent starts
+                ctx.Spawn(Props.FromProducer(() => new ChildActor()));
+                break;
+            case Terminated t:
+                Console.WriteLine($"Child {t.Who} terminated");
+                break;
+        }
+        return Task.CompletedTask;
+    }
+}
+```
+
+In Go:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/asynkron/protoactor-go/actor"
+)
+
+type child struct{}
+
+func (c *child) Receive(ctx actor.Context) {
+    if msg, ok := ctx.Message().(string); ok && msg == "fail" {
+        panic("boom")
+    }
+}
+
+type parent struct{}
+
+func (p *parent) Receive(ctx actor.Context) {
+    switch msg := ctx.Message().(type) {
+    case actor.Started:
+        ctx.Spawn(actor.PropsFromProducer(func() actor.Actor { return &child{} }))
+    case *actor.Terminated:
+        fmt.Println("child terminated")
+    }
+}
+```
+
+## Supervision Diagram
+
+```mermaid
+graph TB
+    parent((Parent))
+    child1((Child))
+    parent --> child1
+```


### PR DESCRIPTION
## Summary
- restructure chapter 2 into an index with links to additional core topics
- document PIDs, supervision, metrics, extensions, dependency injection, and spawning with code samples and diagrams

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68ab268487e08328ac1327a29560889a